### PR TITLE
Profiles cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sable Client Changelog
 
+## Version 1.0.2 - in dev
+
+- Global profile cache & automatic cache clearing on member update events.
+
 ## Version 1.0.1
 
 - (potentially) fixed rare crash when changing rooms

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -23,6 +23,7 @@ import {
   Room,
   RoomEvent,
   RoomEventHandlerMap,
+  RoomStateEvent,
 } from 'matrix-js-sdk';
 import { HTMLReactParserOptions } from 'html-react-parser';
 import classNames from 'classnames';
@@ -965,6 +966,26 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
       }));
     });
   }, [timeline.range, timeline.linkedTimelines, mx, profileCache, getItems, globalProfiles, setGlobalProfiles]);
+
+  useEffect(() => {
+    const onMemberEvent = (event: MatrixEvent) => {
+      if (event.getType() !== StateEvent.RoomMember) return;
+
+      const userId = event.getStateKey();
+      if (!userId) return;
+
+      setGlobalProfiles((prev) => {
+        const next = { ...prev };
+        delete next[userId];
+        return next;
+      });
+    };
+
+    mx.on(RoomStateEvent.Members, onMemberEvent);
+    return () => {
+      mx.removeListener(RoomStateEvent.Members, onMemberEvent);
+    };
+  }, [mx, setGlobalProfiles]);
 
   const handleJumpToLatest = () => {
     if (eventId) {

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -926,7 +926,7 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
       const mEvent = getTimelineEvent(eventTimeline!, getTimelineRelativeIndex(index, baseIndex));
       const senderId = mEvent?.getSender();
 
-      if (senderId && !profileCache[senderId]) {
+      if (senderId && !profileCache[senderId] && !globalProfiles[senderId]) {
         sendersToFetch.add(senderId);
       }
     });
@@ -958,8 +958,13 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
         ...prev,
         [userId]: normalized,
       }));
+
+      setGlobalProfiles((prev) => ({
+        ...prev,
+        [userId]: normalized,
+      }));
     });
-  }, [timeline.range, timeline.linkedTimelines, mx, profileCache, getItems]);
+  }, [timeline.range, timeline.linkedTimelines, mx, profileCache, getItems, globalProfiles, setGlobalProfiles]);
 
   const handleJumpToLatest = () => {
     if (eventId) {
@@ -1146,7 +1151,7 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
             onUsernameClick={handleUsernameClick}
             onReplyClick={handleReplyClick}
             onReactionToggle={handleReactionToggle}
-            senderPronouns={profileCache[senderId]?.pronouns}
+            senderPronouns={profileCache[senderId]?.pronouns || globalProfiles[senderId]?.pronouns}
             onEditId={handleEdit}
             reply={
               replyEventId && (


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Added global profile cache that should also clear profiles when members update their info. We shall see... regardless, always clears on refresh.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
