### PR TITLE
fix: replace --font-mono to make inline codeblocks use mono font

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -133,7 +133,7 @@ audio:not([controls]) {
 
 code,
 pre {
-  font-family: var(--font-mono) !important;
+  font-family: var(--font-monospace) !important;
   font-size: 0.9em !important;
   line-height: 1.3 !important;
   letter-spacing: -0.01em;


### PR DESCRIPTION
### Description

`var(--font-mono)` didn't exist, so I've replaced it with `var(--font-monospace)` which does.

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
