### PR TITLE
Add a counter for unread pins and highlight unread pins in pin menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Codebase cleanup ([#22](https://github.com/7w1/sable/pull/22))
 - Fix mono font ([#18](https://github.com/7w1/sable/pull/18))
 - Merge final commits from ([cinnyapp#2599](https://github.com/cinnyapp/cinny/pull/2599))
+- Pin counter tracks unread pins
 
 ## 1.1.7
 

--- a/src/app/features/room/RoomViewHeader.tsx
+++ b/src/app/features/room/RoomViewHeader.tsx
@@ -320,8 +320,10 @@ export function RoomViewHeader() {
         const newPins = pinnedIds.slice(lastSeenIndex + 1);
         setUnreadPinsCount(newPins.length);
       } else {
-        const countDiff = pinnedIds.length - (pinMarker?.count ?? 0);
-        setUnreadPinsCount(countDiff > 0 ? countDiff : 0);
+        const oldCount = pinMarker?.count ?? 0;
+        const startIndex = Math.max(0, oldCount - 1);
+        const newCount = pinnedIds.length > 0 ? pinnedIds.length - startIndex : 0;
+        setUnreadPinsCount(Math.max(0, newCount));
       }
     };
     checkUnreads();

--- a/src/app/features/room/RoomViewHeader.tsx
+++ b/src/app/features/room/RoomViewHeader.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, forwardRef, useState } from 'react';
+import React, { MouseEventHandler, forwardRef, useEffect, useState } from 'react';
 import FocusTrap from 'focus-trap-react';
 import {
   Box,
@@ -47,7 +47,6 @@ import { roomToUnreadAtom } from '$state/room/roomToUnread';
 import { copyToClipboard } from '$appUtils/dom';
 import { LeaveRoomPrompt } from '$components/leave-room-prompt';
 import { useRoomAvatar, useRoomName, useRoomTopic } from '$hooks/useRoomMeta';
-import { mDirectAtom } from '$state/mDirectList';
 import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
 import { stopPropagation } from '$appUtils/keyboard';
 import { getMatrixToRoom } from '$plugins/matrix-to';
@@ -71,6 +70,17 @@ import { InviteUserPrompt } from '$components/invite-user-prompt';
 import { useCallState } from '$pages/client/call/CallProvider';
 import { ContainerColor } from '$styles/ContainerColor.css';
 import { useRoomWidgets } from '$hooks/useRoomWidgets';
+import { AccountDataEvent } from '$types/matrix/accountData';
+
+async function getPinsHash(pinnedIds: string[]): Promise<string> {
+  const sorted = [...pinnedIds].sort().join(',');
+  const encoder = new TextEncoder();
+  const data = encoder.encode(sorted);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  return hashHex.slice(0, 10);
+}
 
 type RoomMenuProps = {
   room: Room;
@@ -268,7 +278,6 @@ export function RoomViewHeader() {
   const direct = useIsDirectRoom();
 
   const { isChatOpen, toggleChat } = useCallState();
-  const pinnedEvents = useRoomPinnedEvents(room);
   const encryptionEvent = useStateEvent(room, StateEvent.RoomEncryption);
   const encryptedRoom = !!encryptionEvent;
   const avatarMxc = useRoomAvatar(room, direct);
@@ -281,6 +290,42 @@ export function RoomViewHeader() {
   const [peopleDrawer, setPeopleDrawer] = useSetting(settingsAtom, 'isPeopleDrawer');
   const [widgetDrawer, setWidgetDrawer] = useSetting(settingsAtom, 'isWidgetDrawer');
   const widgets = useRoomWidgets(room);
+
+  const pinnedIds = useRoomPinnedEvents(room);
+  const pinMarker = room.getAccountData(AccountDataEvent.SablePinStatus)?.getContent();
+  const [unreadPinsCount, setUnreadPinsCount] = useState(0);
+
+  const [currentHash, setCurrentHash] = useState<string>('');
+
+  useEffect(() => {
+    getPinsHash(pinnedIds).then(setCurrentHash);
+  }, [pinnedIds]);
+
+  useEffect(() => {
+    const checkUnreads = async () => {
+      if (!pinnedIds.length) {
+        setUnreadPinsCount(0);
+        return;
+      }
+
+      const currentHash = await getPinsHash(pinnedIds);
+
+      if (pinMarker?.hash === currentHash) {
+        setUnreadPinsCount(0);
+        return;
+      }
+
+      const lastSeenIndex = pinnedIds.indexOf(pinMarker?.last_seen_id);
+      if (lastSeenIndex !== -1) {
+        const newPins = pinnedIds.slice(lastSeenIndex + 1);
+        setUnreadPinsCount(newPins.length);
+      } else {
+        const countDiff = pinnedIds.length - (pinMarker?.count ?? 0);
+        setUnreadPinsCount(countDiff > 0 ? countDiff : 0);
+      }
+    };
+    checkUnreads();
+  }, [pinnedIds, pinMarker]);
 
   const handleSearchClick = () => {
     const searchParams: _SearchPathSearchParams = {
@@ -296,9 +341,17 @@ export function RoomViewHeader() {
     setMenuAnchor(evt.currentTarget.getBoundingClientRect());
   };
 
-  const handleOpenPinMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
+  const handleOpenPinMenu: MouseEventHandler<HTMLButtonElement> = async (evt) => {
     setPinMenuAnchor(evt.currentTarget.getBoundingClientRect());
+    
+    const currentHash = await getPinsHash(pinnedIds);
+    mx.setRoomAccountData(room.roomId, AccountDataEvent.SablePinStatus, {
+      hash: currentHash,
+      count: pinnedIds.length,
+      last_seen_id: pinnedIds[pinnedIds.length - 1],
+    });
   };
+
 
   return (
     <PageHeader
@@ -411,7 +464,7 @@ export function RoomViewHeader() {
                     ref={triggerRef}
                     aria-pressed={!!pinMenuAnchor}
                   >
-                    {pinnedEvents.length > 0 && (
+                    {unreadPinsCount > 0 && (
                       <Badge
                         style={{
                           position: 'absolute',
@@ -424,7 +477,7 @@ export function RoomViewHeader() {
                         radii="Pill"
                       >
                         <Text as="span" size="L400">
-                          {pinnedEvents.length}
+                          {unreadPinsCount}
                         </Text>
                       </Badge>
                     )}
@@ -447,7 +500,11 @@ export function RoomViewHeader() {
                       escapeDeactivates: stopPropagation,
                     }}
                   >
-                    <RoomPinMenu room={room} requestClose={() => setPinMenuAnchor(undefined)} />
+                    <RoomPinMenu 
+                      room={room} 
+                      requestClose={() => setPinMenuAnchor(undefined)} 
+                      currentHash={currentHash}
+                    />
                   </FocusTrap>
                 }
               />

--- a/src/app/features/room/RoomViewHeader.tsx
+++ b/src/app/features/room/RoomViewHeader.tsx
@@ -357,9 +357,9 @@ export function RoomViewHeader() {
     const updateMarker = async () => {
       if (pinnedIds.length === 0) return;
 
-      const currentHash = await getPinsHash(pinnedIds);
+      const hash = await getPinsHash(pinnedIds);
       await mx.setRoomAccountData(room.roomId, AccountDataEvent.SablePinStatus, {
-        hash: currentHash,
+        hash: hash,
         count: pinnedIds.length,
         last_seen_id: pinnedIds[pinnedIds.length - 1],
       });

--- a/src/app/features/room/RoomViewHeader.tsx
+++ b/src/app/features/room/RoomViewHeader.tsx
@@ -78,8 +78,14 @@ async function getPinsHash(pinnedIds: string[]): Promise<string> {
   const data = encoder.encode(sorted);
   const hashBuffer = await crypto.subtle.digest('SHA-256', data);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
   return hashHex.slice(0, 10);
+}
+
+interface PinReadMarker {
+  hash: string;
+  count: number;
+  last_seen_id: string;
 }
 
 type RoomMenuProps = {
@@ -292,13 +298,15 @@ export function RoomViewHeader() {
   const widgets = useRoomWidgets(room);
 
   const pinnedIds = useRoomPinnedEvents(room);
-  const pinMarker = room.getAccountData(AccountDataEvent.SablePinStatus)?.getContent();
+  const pinMarker = room
+    .getAccountData(AccountDataEvent.SablePinStatus)
+    ?.getContent() as PinReadMarker;
   const [unreadPinsCount, setUnreadPinsCount] = useState(0);
 
   const [currentHash, setCurrentHash] = useState<string>('');
 
   useEffect(() => {
-    getPinsHash(pinnedIds).then(setCurrentHash);
+    void getPinsHash(pinnedIds).then(setCurrentHash);
   }, [pinnedIds]);
 
   useEffect(() => {
@@ -308,9 +316,9 @@ export function RoomViewHeader() {
         return;
       }
 
-      const currentHash = await getPinsHash(pinnedIds);
+      const hash = await getPinsHash(pinnedIds);
 
-      if (pinMarker?.hash === currentHash) {
+      if (pinMarker?.hash === hash) {
         setUnreadPinsCount(0);
         return;
       }
@@ -326,7 +334,7 @@ export function RoomViewHeader() {
         setUnreadPinsCount(Math.max(0, newCount));
       }
     };
-    checkUnreads();
+    void checkUnreads();
   }, [pinnedIds, pinMarker]);
 
   const handleSearchClick = () => {
@@ -343,17 +351,22 @@ export function RoomViewHeader() {
     setMenuAnchor(evt.currentTarget.getBoundingClientRect());
   };
 
-  const handleOpenPinMenu: MouseEventHandler<HTMLButtonElement> = async (evt) => {
+  const handleOpenPinMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {\
     setPinMenuAnchor(evt.currentTarget.getBoundingClientRect());
-    
-    const currentHash = await getPinsHash(pinnedIds);
-    mx.setRoomAccountData(room.roomId, AccountDataEvent.SablePinStatus, {
-      hash: currentHash,
-      count: pinnedIds.length,
-      last_seen_id: pinnedIds[pinnedIds.length - 1],
-    });
-  };
 
+    const updateMarker = async () => {
+      if (pinnedIds.length === 0) return;
+
+      const currentHash = await getPinsHash(pinnedIds);
+      await mx.setRoomAccountData(room.roomId, AccountDataEvent.SablePinStatus, {
+        hash: currentHash,
+        count: pinnedIds.length,
+        last_seen_id: pinnedIds[pinnedIds.length - 1],
+      });
+    };
+
+    void updateMarker();
+  };
 
   return (
     <PageHeader
@@ -502,9 +515,9 @@ export function RoomViewHeader() {
                       escapeDeactivates: stopPropagation,
                     }}
                   >
-                    <RoomPinMenu 
-                      room={room} 
-                      requestClose={() => setPinMenuAnchor(undefined)} 
+                    <RoomPinMenu
+                      room={room}
+                      requestClose={() => setPinMenuAnchor(undefined)}
                       currentHash={currentHash}
                     />
                   </FocusTrap>

--- a/src/app/features/room/RoomViewHeader.tsx
+++ b/src/app/features/room/RoomViewHeader.tsx
@@ -351,7 +351,7 @@ export function RoomViewHeader() {
     setMenuAnchor(evt.currentTarget.getBoundingClientRect());
   };
 
-  const handleOpenPinMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {\
+  const handleOpenPinMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
     setPinMenuAnchor(evt.currentTarget.getBoundingClientRect());
 
     const updateMarker = async () => {

--- a/src/app/features/room/room-pin-menu/RoomPinMenu.tsx
+++ b/src/app/features/room/room-pin-menu/RoomPinMenu.tsx
@@ -298,10 +298,12 @@ export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
     const pinMarker = useMemo(() => 
       room.getAccountData(AccountDataEvent.SablePinStatus)?.getContent(), 
     [room]);
+
     const lastSeenIndex = useMemo(() => {
       if (!pinMarker?.last_seen_id) return -1;
       return pinnedEvents.indexOf(pinMarker.last_seen_id);
     }, [pinnedEvents, pinMarker]);
+
     const hasNewContent = pinMarker?.hash !== currentHash;
 
     const virtualizer = useVirtualizer({
@@ -513,7 +515,15 @@ export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
                       if (!eventId) return null;
 
                       const originalIndex = pinnedEvents.indexOf(eventId);
-                      const isNew = hasNewContent && (lastSeenIndex === -1 || originalIndex > lastSeenIndex);
+                      let isNew = false;
+                      if (pinMarker?.hash !== currentHash) {
+                        if (lastSeenIndex !== -1) {
+                          isNew = originalIndex > lastSeenIndex;
+                        } else {
+                          const oldCount = pinMarker?.count ?? 0;
+                          isNew = originalIndex >= (oldCount - 1);
+                        }
+                      }
 
                       return (
                         <VirtualTile

--- a/src/app/features/room/room-pin-menu/RoomPinMenu.tsx
+++ b/src/app/features/room/room-pin-menu/RoomPinMenu.tsx
@@ -88,6 +88,7 @@ import {
 } from '$hooks/useMemberPowerTag';
 import { useRoomCreatorsTag } from '$hooks/useRoomCreatorsTag';
 import { nicknamesAtom } from '$state/nicknames';
+import { AccountDataEvent } from '$types/matrix/accountData';
 
 type PinnedMessageProps = {
   room: Room;
@@ -100,6 +101,7 @@ type PinnedMessageProps = {
   legacyUsernameColor: boolean;
   hour24Clock: boolean;
   dateFormatString: string;
+  isNew: boolean;
 };
 function PinnedMessage({
   room,
@@ -112,6 +114,7 @@ function PinnedMessage({
   legacyUsernameColor,
   hour24Clock,
   dateFormatString,
+  isNew,
 }: PinnedMessageProps) {
   const pinnedEvent = useRoomEvent(room, eventId);
   const useAuthentication = useMediaAuthentication();
@@ -144,13 +147,19 @@ function PinnedMessage({
 
   const renderOptions = () => (
     <Box shrink="No" gap="200" alignItems="Center">
-      <Chip data-event-id={eventId} onClick={handleOpenClick} variant="Secondary" radii="Pill">
+      <Chip 
+        data-event-id={eventId} 
+        onClick={handleOpenClick} 
+        // Maybe change colors later. design not finalized
+        //variant={isNew ? "Primary" : "Secondary"} 
+        radii="Pill"
+      >
         <Text size="T200">Jump</Text>
       </Chip>
       {canPinEvent && (
         <IconButton
           data-event-id={eventId}
-          variant="Secondary"
+          //variant={isNew ? "Primary" : "Secondary"}
           size="300"
           radii="Pill"
           onClick={unpinState.status === AsyncStatus.Loading ? undefined : handleUnpinClick}
@@ -247,9 +256,10 @@ function PinnedMessage({
 type RoomPinMenuProps = {
   room: Room;
   requestClose: () => void;
+  currentHash: string;
 };
 export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
-  ({ room, requestClose }, ref) => {
+  ({ room, requestClose, currentHash }, ref) => {
     const mx = useMatrixClient();
     const userId = mx.getUserId()!;
     const nicknames = useAtomValue(nicknamesAtom);
@@ -284,6 +294,15 @@ export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
 
     const { navigateRoom } = useRoomNavigate();
     const scrollRef = useRef<HTMLDivElement>(null);
+
+    const pinMarker = useMemo(() => 
+      room.getAccountData(AccountDataEvent.SablePinStatus)?.getContent(), 
+    [room]);
+    const lastSeenIndex = useMemo(() => {
+      if (!pinMarker?.last_seen_id) return -1;
+      return pinnedEvents.indexOf(pinMarker.last_seen_id);
+    }, [pinnedEvents, pinMarker]);
+    const hasNewContent = pinMarker?.hash !== currentHash;
 
     const virtualizer = useVirtualizer({
       count: sortedPinnedEvent.length,
@@ -493,6 +512,9 @@ export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
                       const eventId = sortedPinnedEvent[vItem.index];
                       if (!eventId) return null;
 
+                      const originalIndex = pinnedEvents.indexOf(eventId);
+                      const isNew = hasNewContent && (lastSeenIndex === -1 || originalIndex > lastSeenIndex);
+
                       return (
                         <VirtualTile
                           virtualItem={vItem}
@@ -501,8 +523,12 @@ export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
                           key={vItem.index}
                         >
                           <SequenceCard
-                            style={{ padding: config.space.S400, borderRadius: config.radii.R300 }}
-                            variant="SurfaceVariant"
+                            style={{ 
+                              padding: config.space.S400, 
+                              borderRadius: config.radii.R300,
+                              border: isNew ? `${config.borderWidth.B700} solid ${color.Secondary.ContainerActive}` : undefined,
+                            }}
+                            variant={"Background"}
                             direction="Column"
                           >
                             <PinnedMessage
@@ -515,6 +541,7 @@ export const RoomPinMenu = forwardRef<HTMLDivElement, RoomPinMenuProps>(
                               accessibleTagColors={accessibleTagColors}
                               legacyUsernameColor={legacyUsernameColor || direct}
                               hour24Clock={hour24Clock}
+                              isNew={isNew}
                               dateFormatString={dateFormatString}
                             />
                           </SequenceCard>

--- a/src/types/matrix/accountData.ts
+++ b/src/types/matrix/accountData.ts
@@ -20,6 +20,7 @@ export enum AccountDataEvent {
 
   // Sable account data
   SableNicknames = 'moe.sable.app.nicknames',
+  SablePinStatus = 'moe.sable.app.pins_read_marker',
 }
 
 export type MDirectContent = Record<string, string[]>;


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Replaced the pin counter with the number of unread pins and added a subtle outline to unread messages in the pin list.

<img width="593" height="528" alt="image" src="https://github.com/user-attachments/assets/0ac1e7f3-1121-4f4c-a84b-86bbb45ab7f9" />

Closes #25 using the described implementation until [MSC4238](https://github.com/matrix-org/matrix-spec-proposals/pull/4238) is discussed further/merged.

Stores the following to room account data under the key `moe.sable.app.pins_read_marker`
```json
{
    "hash": "a3f9b2c1d4",
    "count": 7,
    "last_seen_id": "$abc123"
}
```

If the last seen ID is unpinned, it relies on the count to determine which pins to highlight/number to show, subtracting one from the stored count (because that last seen message was unpinned), and then continues to render the number/highlight based on that. This method DOES NOT work when the last seen pin was unpinned in addition to other pins, and will result in any additional pins less than the unpinned pins count being missed.

I unfortunately do not see any way around that issue without keeping track of every single pin message id, which I'd like to avoid.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
