### PR TITLE
Strip quotes for al mxc urls converted to http

### DIFF
--- a/src/app/utils/matrix.ts
+++ b/src/app/utils/matrix.ts
@@ -297,7 +297,7 @@ export const mxcUrlToHttp = (
   allowRedirects?: boolean
 ): string | null =>
   mx.mxcUrlToHttp(
-    mxcUrl,
+    mxcUrl.replace(/^["']|["']$/g, ''),
     width,
     height,
     resizeMethod,


### PR DESCRIPTION
### Description

Adds a quick regex ~~totally not taken from the color hex fix~~ that removes quotes from any mxc url that the `mxcUrlToHttp` function gets.

This should first of all fix uploaded banners not being visible from tuwunel, and I suspect it probably fixes a bunch more things elsewhere as well.

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
