### PR TITLE
Fix Call Rooms' chat button

### DIFF
--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -443,7 +443,7 @@ export function RoomNavItem({
                   offset={4}
                   tooltip={
                     <Tooltip>
-                      <Text>Open Chat</Text>
+                      <Text>{isChatOpen ? 'Hide Chat' : 'Show Chat'}</Text>
                     </Tooltip>
                   }
                 >

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -312,7 +312,7 @@ export function RoomNavItem({
 
   const handleChatButtonClick = (evt: MouseEvent<HTMLButtonElement>) => {
     evt.stopPropagation();
-    if (!isChatOpen) toggleChat();
+    toggleChat();
     setViewedCallRoomId(room.roomId);
     navigate(linkPath);
   };

--- a/src/app/features/room/RoomViewHeader.tsx
+++ b/src/app/features/room/RoomViewHeader.tsx
@@ -648,12 +648,12 @@ export function RoomViewHeader() {
               offset={4}
               tooltip={
                 <Tooltip>
-                  <Text>Chat</Text>
+                  <Text>{isChatOpen ? 'Hide Chat' : 'Show Chat'}</Text>
                 </Tooltip>
               }
             >
               {(triggerRef) => (
-                <IconButton fill="None" ref={triggerRef} onClick={void toggleChat}>
+                <IconButton fill="None" ref={triggerRef} onClick={() => void toggleChat()}>
                   <Icon size="400" src={Icons.Message} filled={isChatOpen} />
                 </IconButton>
               )}


### PR DESCRIPTION
### Description

Previously, in call rooms, the small chat button next to the room name in the room list was capable of opening the chat but not close it, while the bigger chat button on the top right just did nothing. This PR addresses and fixes both of these, as they now both toggle the chat on and off all the time.

Additionally, as an extra, both now have a "show chat"/"hide chat" tooltip, for consistency.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
