### PR TITLE
Add experimental settings page

### DIFF
--- a/src/app/features/settings/Settings.tsx
+++ b/src/app/features/settings/Settings.tsx
@@ -34,6 +34,7 @@ import { About } from './about';
 import { Account } from './account';
 import { General } from './general';
 import { Cosmetics } from './cosmetics/Cosmetics';
+import { Experimental } from './experimental/Experimental';
 
 export enum SettingsPages {
   GeneralPage,
@@ -43,6 +44,7 @@ export enum SettingsPages {
   EmojisStickersPage,
   CosmeticsPage,
   DeveloperToolsPage,
+  ExperimentalPage,
   AboutPage,
 }
 
@@ -91,6 +93,11 @@ const useSettingsMenuItems = (): SettingsMenuItem[] =>
         page: SettingsPages.DeveloperToolsPage,
         name: 'Developer Tools',
         icon: Icons.Terminal,
+      },
+      {
+        page: SettingsPages.ExperimentalPage,
+        name: 'Experimental',
+        icon: Icons.Funnel,
       },
       {
         page: SettingsPages.AboutPage,
@@ -247,6 +254,9 @@ export function Settings({ initialPage, requestClose }: SettingsProps) {
       )}
       {activePage === SettingsPages.DeveloperToolsPage && (
         <DeveloperTools requestClose={handlePageRequestClose} />
+      )}
+      {activePage === SettingsPages.ExperimentalPage && (
+        <Experimental requestClose={handlePageRequestClose} />
       )}
       {activePage === SettingsPages.AboutPage && <About requestClose={handlePageRequestClose} />}
     </PageRoot>

--- a/src/app/features/settings/experimental/Experimental.tsx
+++ b/src/app/features/settings/experimental/Experimental.tsx
@@ -1,0 +1,46 @@
+import { Box, Text, IconButton, Icon, Icons, Scroll, } from 'folds';
+import { Page, PageContent, PageHeader } from '$components/page';
+import { InfoCard } from '$components/info-card';
+
+type ExperimentalProps = {
+  requestClose: () => void;
+};
+export function Experimental({ requestClose }: ExperimentalProps) {
+  return (
+    <Page>
+      <PageHeader outlined={false}>
+        <Box grow="Yes" gap="200">
+          <Box grow="Yes" alignItems="Center" gap="200">
+            <Text size="H3" truncate>
+              Experimental
+            </Text>
+          </Box>
+          <Box shrink="No">
+            <IconButton onClick={requestClose} variant="Surface">
+              <Icon src={Icons.Cross} />
+            </IconButton>
+          </Box>
+        </Box>
+      </PageHeader>
+      <Box grow="Yes">
+        <Scroll hideTrack visibility="Hover">
+          <PageContent>
+            <InfoCard
+              before=<Icon src={Icons.Warning} size="100" filled />
+              variant="Warning"
+              description={
+                <>
+                  The features listed below may be unstable or incomplete,
+                  <strong> use at your own risk</strong>.
+                  <br />
+                  Please report any new issues potentially caused by these features!
+                </>
+              }
+            />
+
+          </PageContent>
+        </Scroll>
+      </Box>
+    </Page>
+  );
+}

--- a/src/app/features/settings/experimental/Experimental.tsx
+++ b/src/app/features/settings/experimental/Experimental.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, IconButton, Icon, Icons, Scroll, } from 'folds';
 import { Page, PageContent, PageHeader } from '$components/page';
 import { InfoCard } from '$components/info-card';
+import { Sync } from '../general';
 
 type ExperimentalProps = {
   requestClose: () => void;
@@ -37,7 +38,10 @@ export function Experimental({ requestClose }: ExperimentalProps) {
                 </>
               }
             />
-
+            <br />
+            <Box direction="Column" gap="700">
+              <Sync />
+            </Box>
           </PageContent>
         </Scroll>
       </Box>

--- a/src/app/features/settings/experimental/Experimental.tsx
+++ b/src/app/features/settings/experimental/Experimental.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, IconButton, Icon, Icons, Scroll, } from 'folds';
+import { Box, Text, IconButton, Icon, Icons, Scroll } from 'folds';
 import { Page, PageContent, PageHeader } from '$components/page';
 import { InfoCard } from '$components/info-card';
 import { Sync } from '../general';

--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -780,7 +780,7 @@ function Messages() {
   );
 }
 
-function Sync() {
+export function Sync() {
   const clientConfig = useClientConfig();
   const sessions = useAtomValue(sessionsAtom);
   const activeSessionId = useAtomValue(activeSessionIdAtom);
@@ -857,7 +857,6 @@ export function General({ requestClose }: GeneralProps) {
           <PageContent>
             <Box direction="Column" gap="700">
               <DateAndTime />
-              <Sync />
               <Gestures isMobile={mobileOrTablet()} />
               <Editor isMobile={mobileOrTablet()} />
               <Messages />


### PR DESCRIPTION
### Description

This PR adds a new settings page for Experimental features that are still incomplete and unstable so that that users don't accidentally screw themselves over.

Currently, only the new Sliding Sync is in this page.
 
#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
