### PR TITLE
Display acount status in the member drawer and profile card

### DIFF
--- a/src/app/components/presence/Presence.tsx
+++ b/src/app/components/presence/Presence.tsx
@@ -22,10 +22,9 @@ const PresenceToColor: Record<Presence, MainColor> = {
 
 type PresenceBadgeProps = {
   presence: Presence;
-  status?: string;
   size?: '200' | '300' | '400' | '500';
 };
-export function PresenceBadge({ presence, status, size }: PresenceBadgeProps) {
+export function PresenceBadge({ presence, size }: PresenceBadgeProps) {
   const label = usePresenceLabel();
   const badgeLabelId = useId();
 
@@ -39,8 +38,6 @@ export function PresenceBadge({ presence, status, size }: PresenceBadgeProps) {
         <Tooltip id={badgeLabelId}>
           <Box style={{ maxWidth: toRem(250) }} alignItems="Baseline" gap="100">
             <Text size="L400">{label[presence]}</Text>
-            {status && <Text size="T200">•</Text>}
-            {status && <Text size="T200">{status}</Text>}
           </Box>
         </Tooltip>
       }

--- a/src/app/components/user-profile/UserHero.tsx
+++ b/src/app/components/user-profile/UserHero.tsx
@@ -10,6 +10,7 @@ import {
   OverlayCenter,
   Text,
   Tooltip,
+  toRem,
 } from 'folds';
 import classNames from 'classnames';
 import FocusTrap from 'focus-trap-react';
@@ -35,6 +36,7 @@ type UserHeroProps = {
 };
 export function UserHero({ userId, avatarUrl, bannerUrl, presence }: UserHeroProps) {
   const [viewAvatar, setViewAvatar] = useState<string>();
+  const [isFullStatus, setIsFullStatus] = useState(false);
 
   const cachedBannerUrl = useBlobCache(bannerUrl);
   const cachedAvatarUrl = useBlobCache(avatarUrl);
@@ -105,8 +107,23 @@ export function UserHero({ userId, avatarUrl, bannerUrl, presence }: UserHeroPro
         </div>
         {presence?.status?.length && (
           <div className={css.UserHeroStatusContainer}>
-            <Tooltip style={{ maxWidth: '90%', justifySelf: 'left' }}>
-              <Text size="T200"> {presence.status} </Text>
+            <Tooltip
+              onClick={() => setIsFullStatus(!isFullStatus)}
+              className={css.UserHeroStatusTooltip}
+              style={{
+                maxHeight: isFullStatus ? toRem(105) : toRem(48),
+              }}
+            >
+              <Text
+                size="T200"
+                style={{
+                  overflow: isFullStatus ? 'scroll' : 'hidden',
+                  height: '100%',
+                  wordBreak: 'break-word',
+                }}
+              >
+                {presence.status}
+              </Text>
             </Tooltip>
           </div>
         )}

--- a/src/app/components/user-profile/UserHero.tsx
+++ b/src/app/components/user-profile/UserHero.tsx
@@ -9,6 +9,7 @@ import {
   OverlayBackdrop,
   OverlayCenter,
   Text,
+  Tooltip,
 } from 'folds';
 import classNames from 'classnames';
 import FocusTrap from 'focus-trap-react';
@@ -58,51 +59,58 @@ export function UserHero({ userId, avatarUrl, bannerUrl, presence }: UserHeroPro
           />
         )}
       </div>
-      <div className={css.UserHeroAvatarContainer}>
-        <AvatarPresence
-          className={css.UserAvatarContainer}
-          badge={
-            presence && <PresenceBadge presence={presence.presence} status={presence.status} />
-          }
-        >
-          <Avatar
-            as={avatarUrl ? 'button' : 'div'}
-            onClick={avatarUrl ? () => setViewAvatar(avatarUrl) : undefined}
-            className={css.UserHeroAvatar}
-            size="500"
+      <Box direction="Row" className={css.UserHeroAvatarStatusContainer}>
+        <div className={css.UserHeroAvatarContainer}>
+          <AvatarPresence
+            className={css.UserAvatarContainer}
+            badge={presence && <PresenceBadge presence={presence.presence} />}
           >
-            <UserAvatar
-              className={css.UserHeroAvatarImg}
-              userId={userId}
-              src={avatarUrl}
-              alt={userId}
-              renderFallback={() => <Icon size="500" src={Icons.User} filled />}
-            />
-          </Avatar>
-        </AvatarPresence>
-        {viewAvatar && (
-          <Overlay open backdrop={<OverlayBackdrop />}>
-            <OverlayCenter>
-              <FocusTrap
-                focusTrapOptions={{
-                  initialFocus: false,
-                  onDeactivate: () => setViewAvatar(undefined),
-                  clickOutsideDeactivates: true,
-                  escapeDeactivates: stopPropagation,
-                }}
-              >
-                <Modal size="500" onContextMenu={(evt: any) => evt.stopPropagation()}>
-                  <ImageViewer
-                    src={viewAvatar}
-                    alt={userId}
-                    requestClose={() => setViewAvatar(undefined)}
-                  />
-                </Modal>
-              </FocusTrap>
-            </OverlayCenter>
-          </Overlay>
+            <Avatar
+              as={avatarUrl ? 'button' : 'div'}
+              onClick={avatarUrl ? () => setViewAvatar(avatarUrl) : undefined}
+              className={css.UserHeroAvatar}
+              size="500"
+            >
+              <UserAvatar
+                className={css.UserHeroAvatarImg}
+                userId={userId}
+                src={avatarUrl}
+                alt={userId}
+                renderFallback={() => <Icon size="500" src={Icons.User} filled />}
+              />
+            </Avatar>
+          </AvatarPresence>
+          {viewAvatar && (
+            <Overlay open backdrop={<OverlayBackdrop />}>
+              <OverlayCenter>
+                <FocusTrap
+                  focusTrapOptions={{
+                    initialFocus: false,
+                    onDeactivate: () => setViewAvatar(undefined),
+                    clickOutsideDeactivates: true,
+                    escapeDeactivates: stopPropagation,
+                  }}
+                >
+                  <Modal size="500" onContextMenu={(evt: any) => evt.stopPropagation()}>
+                    <ImageViewer
+                      src={viewAvatar}
+                      alt={userId}
+                      requestClose={() => setViewAvatar(undefined)}
+                    />
+                  </Modal>
+                </FocusTrap>
+              </OverlayCenter>
+            </Overlay>
+          )}
+        </div>
+        {presence?.status?.length && (
+          <div className={css.UserHeroStatusContainer}>
+            <Tooltip style={{ maxWidth: '90%', justifySelf: 'left' }}>
+              <Text size="T200"> {presence.status} </Text>
+            </Tooltip>
+          </div>
         )}
-      </div>
+      </Box>
     </Box>
   );
 }

--- a/src/app/components/user-profile/UserHero.tsx
+++ b/src/app/components/user-profile/UserHero.tsx
@@ -124,6 +124,13 @@ export function UserHero({ userId, avatarUrl, bannerUrl, presence }: UserHeroPro
               >
                 {presence.status}
               </Text>
+              {presence.status.length > 70 && (
+                <Icon
+                  size="50"
+                  style={{ position: 'relative', left: '2.5%' }}
+                  src={isFullStatus ? Icons.ChevronTop : Icons.ChevronBottom}
+                />
+              )}
             </Tooltip>
           </div>
         )}

--- a/src/app/components/user-profile/styles.css.ts
+++ b/src/app/components/user-profile/styles.css.ts
@@ -54,6 +54,15 @@ export const UserHeroStatusContainer = style({
   width: '100%',
   paddingLeft: '2%',
 });
+export const UserHeroStatusTooltip = style({
+  maxWidth: '98%',
+  justifySelf: 'left',
+  cursor: 'pointer',
+  ':hover': {
+    filter: 'brightness(0.8)',
+    transform: 'translateY(-1px)',
+  },
+});
 export const UserHeroAvatar = style({
   outline: `${config.borderWidth.B600} solid ${color.Surface.Container}`,
   selectors: {

--- a/src/app/components/user-profile/styles.css.ts
+++ b/src/app/components/user-profile/styles.css.ts
@@ -31,16 +31,28 @@ export const UserHeroCoverFallback = style({
   transform: 'scale(2)',
 });
 
-export const UserHeroAvatarContainer = style({
+export const UserHeroAvatarStatusContainer = style({
   position: 'relative',
   height: toRem(29),
+  width: '100%',
+});
+export const UserHeroAvatarContainer = style({
+  position: 'relative',
+  paddingLeft: config.space.S400,
 });
 export const UserAvatarContainer = style({
-  position: 'absolute',
-  left: config.space.S400,
+  position: 'relative',
   top: 0,
   transform: 'translateY(-50%)',
   backgroundColor: color.Surface.Container,
+});
+export const UserHeroStatusContainer = style({
+  position: 'relative',
+  transform: 'translateY(-50%)',
+  textAlign: 'justify',
+  display: 'grid',
+  width: '100%',
+  paddingLeft: '2%',
 });
 export const UserHeroAvatar = style({
   outline: `${config.borderWidth.B600} solid ${color.Surface.Container}`,

--- a/src/app/features/room/MembersDrawer.tsx
+++ b/src/app/features/room/MembersDrawer.tsx
@@ -30,6 +30,8 @@ import { MatrixClient, Room, RoomMember } from '$types/matrix-sdk';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import classNames from 'classnames';
 
+import { AvatarPresence, PresenceBadge } from '$components/presence';
+import { useUserPresence } from '$hooks/useUserPresence';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { UseStateProvider } from '$components/UseStateProvider';
 import { SearchItemStrGetter, UseAsyncSearchOptions, useAsyncSearch } from '$hooks/useAsyncSearch';
@@ -128,6 +130,7 @@ function MemberItem({
     ? mx.mxcUrlToHttp(avatarMxcUrl, 100, 100, 'crop', undefined, false, useAuthentication)
     : undefined;
 
+  const presence = useUserPresence(member.userId);
   const { color, font } = useSableCosmetics(member.userId, room);
 
   return (
@@ -139,14 +142,18 @@ function MemberItem({
       radii="400"
       onClick={onClick}
       before={
-        <Avatar size="200">
-          <UserAvatar
-            userId={member.userId}
-            src={avatarUrl ?? undefined}
-            alt={name}
-            renderFallback={() => <Icon size="50" src={Icons.User} filled />}
-          />
-        </Avatar>
+        <AvatarPresence
+          badge={presence && <PresenceBadge presence={presence.presence} size="200" />}
+        >
+          <Avatar size="200">
+            <UserAvatar
+              userId={member.userId}
+              src={avatarUrl ?? undefined}
+              alt={name}
+              renderFallback={() => <Icon size="50" src={Icons.User} filled />}
+            />
+          </Avatar>
+        </AvatarPresence>
       }
       after={
         typing && (
@@ -156,10 +163,16 @@ function MemberItem({
         )
       }
     >
-      <Box grow="Yes">
+      <Box direction="Column" grow="Yes">
         <Text size="T400" truncate style={{ color, fontFamily: font }}>
           {name}
         </Text>
+        {presence?.status && (
+          /* The Color value should be edited to the theme specific disabled text color */
+          <Text size="T300" truncate style={{ color: '#888888', fontFamily: font }}>
+            {presence.status}
+          </Text>
+        )}
       </Box>
     </MenuItem>
   );

--- a/src/app/features/room/MembersDrawer.tsx
+++ b/src/app/features/room/MembersDrawer.tsx
@@ -168,8 +168,7 @@ function MemberItem({
           {name}
         </Text>
         {presence?.status && (
-          /* The Color value should be edited to the theme specific disabled text color */
-          <Text size="T300" truncate style={{ color: '#888888', fontFamily: font }}>
+          <Text size="T300" truncate style={{ color: config.opacity.P300, fontFamily: font }}>
             {presence.status}
           </Text>
         )}


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

This pull request makes it so that within the hero (profile card) and the member drawer you are able to see the presence (online, busy, unavailable), and the status message (a custom message) of a person.

This is how it would display using this code:
<img width="272" height="1034" alt="image" src="https://github.com/user-attachments/assets/1489e3c9-ed24-48f3-8e0a-18e16b6dd317" />
<img width="352" height="338" alt="image" src="https://github.com/user-attachments/assets/2cc1ba3d-7731-4c80-8e4f-8ee6492d8b40" />

This pr is based on a (1 day) old version of sable

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
