### PR TITLE
fix(notifications): reliable notification delivery and push grouping

### DIFF
--- a/src/app/hooks/useNotificationJumper.ts
+++ b/src/app/hooks/useNotificationJumper.ts
@@ -17,9 +17,18 @@ export function NotificationJumper() {
   const performJump = useCallback(() => {
     if (!pending) return;
     if (pending.targetSessionId && pending.targetSessionId !== activeSessionId) {
-      log.log('waiting for target session...', {
+      log.log('waiting for target session atom...', {
         targetSessionId: pending.targetSessionId,
         activeSessionId,
+      });
+      return;
+    }
+
+    // Guard: the mx client context may lag one render behind the atom — wait until it catches up
+    if (pending.targetSessionId && mx.getUserId() !== pending.targetSessionId) {
+      log.log('waiting for mx client to switch to target session...', {
+        targetSessionId: pending.targetSessionId,
+        currentUserId: mx.getUserId(),
       });
       return;
     }

--- a/src/app/pages/client/BackgroundNotifications.tsx
+++ b/src/app/pages/client/BackgroundNotifications.tsx
@@ -29,16 +29,16 @@ import { NotificationType, StateEvent } from '$types/matrix/room';
 import { createLogger } from '$utils/debug';
 import LogoSVG from '$public/res/svg/cinny.svg';
 import { nicknamesAtom } from '$state/nicknames';
-import { useMatrixClient } from '$hooks/useMatrixClient';
 import {
   buildRoomMessageNotification,
   resolveNotificationPreviewText,
 } from '$utils/notificationStyle';
-import { mobileOrTablet } from '$utils/user-agent';
 import { startClient, stopClient } from '$client/initMatrix';
 import { useClientConfig } from '$hooks/useClientConfig';
 
 const log = createLogger('BackgroundNotifications');
+const isClientReadyForNotifications = (state: SyncState | string | null): boolean =>
+  state === SyncState.Prepared || state === SyncState.Syncing || state === SyncState.Catchup;
 
 const startBackgroundClient = async (
   session: Session,
@@ -66,12 +66,12 @@ const startBackgroundClient = async (
 const waitForSync = (mx: MatrixClient): Promise<void> =>
   new Promise((resolve) => {
     const state = mx.getSyncState();
-    if (state === SyncState.Syncing) {
+    if (isClientReadyForNotifications(state)) {
       resolve();
       return;
     }
     const onSync = (newState: SyncState) => {
-      if (newState === SyncState.Syncing) {
+      if (isClientReadyForNotifications(newState)) {
         mx.removeListener(ClientEvent.Sync, onSync);
         resolve();
       }
@@ -92,11 +92,19 @@ export function BackgroundNotifications() {
     settingsAtom,
     'showMessageContentInEncryptedNotifications'
   );
-  const forcePushOnMobile = usePushNotifications && mobileOrTablet();
-  const activeMx = useMatrixClient();
+  const shouldRunBackgroundNotifications = showNotifications || usePushNotifications;
   const nicknames = useAtomValue(nicknamesAtom);
   const nicknamesRef = useRef(nicknames);
   nicknamesRef.current = nicknames;
+  // Refs so handleTimeline callbacks always read current settings without stale closures
+  const showNotificationsRef = useRef(showNotifications);
+  showNotificationsRef.current = showNotifications;
+  const notificationSoundRef = useRef(notificationSound);
+  notificationSoundRef.current = notificationSound;
+  const showMessageContentRef = useRef(showMessageContent);
+  showMessageContentRef.current = showMessageContent;
+  const showEncryptedMessageContentRef = useRef(showEncryptedMessageContent);
+  showEncryptedMessageContentRef.current = showEncryptedMessageContent;
   const clientsRef = useRef<Map<string, MatrixClient>>(new Map());
   const notifiedEventsRef = useRef<Set<string>>(new Set());
   const setPending = useSetAtom(pendingNotificationAtom);
@@ -116,13 +124,14 @@ export function BackgroundNotifications() {
     badge?: string;
     /** If `true` the notification plays no sound. */
     silent?: boolean;
+    /** Arbitrary payload attached to the notification. */
+    data?: unknown;
     /** Callback when the user taps/clicks the notification. */
     onClick?: () => void;
   }
 
   useEffect(() => {
-    if (forcePushOnMobile) return undefined;
-    if (!showNotifications) return undefined;
+    if (!shouldRunBackgroundNotifications) return undefined;
 
     const { current } = clientsRef;
     const activeIds = new Set(inactiveSessions.map((s) => s.userId));
@@ -134,6 +143,7 @@ export function BackgroundNotifications() {
           badge: opts.badge,
           body: opts.body,
           silent: opts.silent ?? false,
+          data: opts.data,
         });
         if (opts.onClick) {
           const cb = opts.onClick;
@@ -176,18 +186,17 @@ export function BackgroundNotifications() {
             removed: boolean,
             data: { liveEvent: boolean }
           ) => {
-            if (mx.getSyncState() !== 'SYNCING') return;
+            if (!isClientReadyForNotifications(mx.getSyncState())) return;
             if (!room || !data?.liveEvent || room.isSpaceRoom()) return;
             if (!isNotificationEvent(mEvent)) return;
 
             const notifType = getNotificationType(mx, room.roomId);
             if (notifType === NotificationType.Mute) return;
 
-            const activeRoom = activeMx.getRoom(room.roomId);
-            if (activeRoom?.getMyMembership() === 'join') return;
-
             const eventId = mEvent.getId();
-            if (!eventId || notifiedEventsRef.current.has(eventId)) return;
+            if (!eventId) return;
+            const dedupeId = `${session.userId}:${eventId}`;
+            if (notifiedEventsRef.current.has(dedupeId)) return;
 
             const sender = mEvent.getSender();
             if (!sender || sender === mx.getUserId()) return;
@@ -206,28 +215,34 @@ export function BackgroundNotifications() {
               ? (mxcUrlToHttp(mx, avatarMxc, false, 96, 96, 'crop') ?? undefined)
               : LogoSVG;
 
-            const isHighlight = pushActions.tweaks?.highlight === true;
+            const loudByRule = Boolean(pushActions.tweaks?.sound);
+            // Silent-rule events: update badges only, no OS notification or sound
+            if (!loudByRule) return;
+
             const isEncryptedRoom = !!getStateEvent(room, StateEvent.RoomEncryption);
 
-            notifiedEventsRef.current.add(eventId);
+            notifiedEventsRef.current.add(dedupeId);
             // Cap the set so it doesn't grow unbounded
             if (notifiedEventsRef.current.size > 200) {
               const first = notifiedEventsRef.current.values().next().value;
               if (first) notifiedEventsRef.current.delete(first);
             }
 
+            // Respect in-app notification setting (read from ref to avoid stale closure)
+            if (!showNotificationsRef.current) return;
+
             const notificationPayload = buildRoomMessageNotification({
-              roomName: room.name ?? 'Unknown',
+              roomName: room.name ?? room.getCanonicalAlias() ?? room.roomId,
               roomAvatar,
               username: senderName,
               previewText: resolveNotificationPreviewText({
                 content: mEvent.getContent(),
                 eventType: mEvent.getType(),
                 isEncryptedRoom,
-                showMessageContent,
-                showEncryptedMessageContent,
+                showMessageContent: showMessageContentRef.current,
+                showEncryptedMessageContent: showEncryptedMessageContentRef.current,
               }),
-              silent: !notificationSound || !isHighlight,
+              silent: !notificationSoundRef.current,
               eventId,
               data: {
                 type: mEvent.getType(),
@@ -243,10 +258,12 @@ export function BackgroundNotifications() {
               badge: notificationPayload.options.badge,
               body: notificationPayload.options.body,
               silent: notificationPayload.options.silent ?? undefined,
+              data: notificationPayload.options.data,
               onClick: () => {
                 window.focus();
+                // Always switch to the background account – jotai ignores no-op updates
+                setActiveSessionId(session.userId);
                 setPending({ roomId: room.roomId, eventId, targetSessionId: session.userId });
-                if (session.userId !== activeSessionId) setActiveSessionId(session.userId);
               },
             });
           };
@@ -265,13 +282,7 @@ export function BackgroundNotifications() {
   }, [
     clientConfig.slidingSync,
     inactiveSessions,
-    forcePushOnMobile,
-    showNotifications,
-    notificationSound,
-    showMessageContent,
-    showEncryptedMessageContent,
-    activeMx,
-    activeSessionId,
+    shouldRunBackgroundNotifications,
     setActiveSessionId,
     setPending,
   ]);

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -89,13 +89,24 @@ function FaviconUpdater() {
     }
     try {
       navigator.setAppBadge(total);
-      if (usePushNotifications && total === 0) {
-        registration
-          .getNotifications()
-          .then((pushNotifications) =>
-            pushNotifications.forEach((pushNotification) => pushNotification.close())
-          );
-        navigator.clearAppBadge();
+      if (usePushNotifications) {
+        if (total === 0) {
+          // All rooms read — clear every notification and the badge.
+          registration.getNotifications().then((notifs) => notifs.forEach((n) => n.close()));
+          navigator.clearAppBadge();
+        } else {
+          // Dismiss notifications for individual rooms that are now fully read.
+          registration.getNotifications().then((notifs) => {
+            notifs.forEach((n) => {
+              const notifRoomId = n.data?.room_id;
+              if (!notifRoomId) return;
+              const roomUnread = roomToUnread.get(notifRoomId);
+              if (!roomUnread || (roomUnread.total === 0 && roomUnread.highlight === 0)) {
+                n.close();
+              }
+            });
+          });
+        }
       }
     } catch {
       // Likely Firefox/Gecko-based and doesn't support badging API

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { ReactNode, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { EventType, RoomEvent, RoomEventHandlerMap } from '$types/matrix-sdk';
+import { EventType, PushProcessor, RoomEvent, RoomEventHandlerMap } from '$types/matrix-sdk';
 import { roomToUnreadAtom, unreadEqual, unreadInfoToUnread } from '$state/room/roomToUnread';
 import LogoSVG from '$public/res/svg/cinny.svg';
 import LogoUnreadSVG from '$public/res/svg/cinny-unread.svg';
@@ -115,7 +115,6 @@ function InviteNotifications() {
   const [showNotifications] = useSetting(settingsAtom, 'useInAppNotifications');
   const [usePushNotifications] = useSetting(settingsAtom, 'usePushNotifications');
   const [notificationSound] = useSetting(settingsAtom, 'isNotificationSounds');
-  const forcePushOnMobile = usePushNotifications && mobileOrTablet();
 
   const notify = useCallback(
     (count: number) => {
@@ -140,16 +139,22 @@ function InviteNotifications() {
   }, []);
 
   useEffect(() => {
-    if (forcePushOnMobile) return;
-    if (usePushNotifications && document.visibilityState !== 'visible') return;
-    if (invites.length > perviousInviteLen && mx.getSyncState() === 'SYNCING') {
-      if (showNotifications && notificationPermission('granted')) {
-        notify(invites.length - perviousInviteLen);
-      }
+    if (invites.length <= perviousInviteLen || mx.getSyncState() !== 'SYNCING') return;
 
-      if (notificationSound) {
-        playSound();
-      }
+    // Page hidden: if push is enabled, SW handles the OS notification. If not, nothing to do.
+    if (document.visibilityState !== 'visible') return;
+
+    // Page is visible — show in-app experience.
+    // On mobile with push: iOS-style — play sound only, no OS notification (SW is silent when
+    // the app is visible on mobile, matching foreground behaviour of native chat apps).
+    // On desktop with push: SW skipped (saw a visible client), so we show the OS notification.
+    // Without push: always show OS notification when page is visible.
+    const isVisibleMobileWithPush = usePushNotifications && mobileOrTablet();
+    if (!isVisibleMobileWithPush && showNotifications && notificationPermission('granted')) {
+      notify(invites.length - perviousInviteLen);
+    }
+    if (notificationSound) {
+      playSound();
     }
   }, [
     mx,
@@ -157,7 +162,6 @@ function InviteNotifications() {
     perviousInviteLen,
     showNotifications,
     usePushNotifications,
-    forcePushOnMobile,
     notificationSound,
     notify,
     playSound,
@@ -185,7 +189,6 @@ function MessageNotifications() {
     settingsAtom,
     'showMessageContentInEncryptedNotifications'
   );
-  const forcePushOnMobile = usePushNotifications && mobileOrTablet();
   const nicknames = useAtomValue(nicknamesAtom);
   const nicknamesRef = useRef(nicknames);
   nicknamesRef.current = nicknames;
@@ -202,6 +205,7 @@ function MessageNotifications() {
       roomId,
       eventId,
       previewText,
+      silent,
     }: {
       roomName: string;
       roomAvatar?: string;
@@ -209,13 +213,14 @@ function MessageNotifications() {
       roomId: string;
       eventId: string;
       previewText: string;
+      silent: boolean;
     }) => {
       const payload = buildRoomMessageNotification({
         roomName,
         roomAvatar,
         username,
         previewText,
-        silent: true,
+        silent,
         eventId,
       });
       const noti = new window.Notification(payload.title, payload.options);
@@ -240,6 +245,7 @@ function MessageNotifications() {
   }, []);
 
   useEffect(() => {
+    const pushProcessor = new PushProcessor(mx);
     const handleTimelineEvent: RoomEventHandlerMap[RoomEvent.Timeline] = (
       mEvent,
       room,
@@ -247,9 +253,7 @@ function MessageNotifications() {
       removed,
       data
     ) => {
-      if (forcePushOnMobile) return;
       if (mx.getSyncState() !== 'SYNCING') return;
-      if (usePushNotifications && document.visibilityState !== 'visible') return;
       if (document.hasFocus() && (selectedRoomId === room?.roomId || notificationSelected)) return;
 
       if (
@@ -265,6 +269,9 @@ function MessageNotifications() {
       const sender = mEvent.getSender();
       const eventId = mEvent.getId();
       if (!sender || !eventId || mEvent.getSender() === mx.getUserId()) return;
+      const pushActions = pushProcessor.actionsForEvent(mEvent);
+      if (!pushActions?.notify) return;
+      const loudByRule = Boolean(pushActions.tweaks?.sound);
       const unreadInfo = getUnreadInfo(room);
       const cachedUnreadInfo = unreadCacheRef.current.get(room.roomId);
       unreadCacheRef.current.set(room.roomId, unreadInfo);
@@ -277,7 +284,21 @@ function MessageNotifications() {
         return;
       }
 
-      if (showNotifications && notificationPermission('granted')) {
+      // Page hidden: if push is enabled, SW handles the OS notification. If not, nothing to do.
+      if (document.visibilityState !== 'visible') return;
+
+      // Page is visible — show in-app experience.
+      // On mobile with push: iOS-style — play sound only, no OS notification (SW is silent when
+      // the app is visible on mobile, matching foreground behaviour of native chat apps).
+      // On desktop with push: SW skipped (saw a visible client), so we show the OS notification.
+      // Without push: always show OS notification when page is visible.
+      const isVisibleMobileWithPush = usePushNotifications && mobileOrTablet();
+      if (
+        !isVisibleMobileWithPush &&
+        loudByRule &&
+        showNotifications &&
+        notificationPermission('granted')
+      ) {
         const isEncryptedRoom = !!getStateEvent(room, StateEvent.RoomEncryption);
         const avatarMxc =
           room.getAvatarFallbackMember()?.getMxcAvatarUrl() ?? room.getMxcAvatarUrl();
@@ -299,10 +320,11 @@ function MessageNotifications() {
             showMessageContent,
             showEncryptedMessageContent,
           }),
+          silent: !notificationSound,
         });
       }
 
-      if (notificationSound) {
+      if (notificationSound && loudByRule) {
         playSound();
       }
     };
@@ -318,7 +340,6 @@ function MessageNotifications() {
     showMessageContent,
     showEncryptedMessageContent,
     usePushNotifications,
-    forcePushOnMobile,
     playSound,
     notify,
     selectedRoomId,
@@ -353,7 +374,6 @@ type ClientNonUIFeaturesProps = {
 
 function HandleNotificationClick() {
   const navigate = useNavigate();
-  const activeSessionId = useAtomValue(activeSessionIdAtom);
   const setActiveSessionId = useSetAtom(activeSessionIdAtom);
   const setPending = useSetAtom(pendingNotificationAtom);
 
@@ -374,9 +394,9 @@ function HandleNotificationClick() {
       switch (eventType) {
         case EventType.RoomMessage:
         case EventType.RoomMessageEncrypted:
-          if (targetSessionId && targetSessionId !== activeSessionId) {
-            setActiveSessionId(targetSessionId);
-          }
+          // Always set the target session — jotai ignores no-ops if already active.
+          // This ensures we never accidentally navigate under the wrong account.
+          if (targetSessionId) setActiveSessionId(targetSessionId);
           setPending({
             roomId: messageData!.room_id,
             eventId: messageData!.event_id,
@@ -385,9 +405,7 @@ function HandleNotificationClick() {
           return;
         case EventType.RoomMember:
           if (!(messageData?.content?.membership === 'invite')) return;
-          if (targetSessionId && targetSessionId !== activeSessionId) {
-            setActiveSessionId(targetSessionId);
-          }
+          if (targetSessionId) setActiveSessionId(targetSessionId);
           navigate(getInboxInvitesPath());
           break;
         default:
@@ -399,7 +417,7 @@ function HandleNotificationClick() {
     return () => {
       navigator.serviceWorker.removeEventListener('message', handleNotificationClickEvent);
     };
-  }, [activeSessionId, navigate, setActiveSessionId, setPending]);
+  }, [navigate, setActiveSessionId, setPending]);
 
   return null;
 }
@@ -415,7 +433,9 @@ function SyncNotificationSettingsWithServiceWorker() {
 
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return;
-    const preferPushOnMobile = usePushNotifications && mobileOrTablet();
+    // preferPushOnMobile=false: SW skips push when page is visible on all devices.
+    // The in-app path handles the visible case (sound on mobile, OS notification on desktop).
+    const preferPushOnMobile = false;
     const payload = {
       type: 'setNotificationSettings' as const,
       notificationSoundEnabled: notificationSound,

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -240,8 +240,7 @@ export const getUnreadInfo = (room: Room, options?: UnreadInfoOptions): UnreadIn
   }
 
   let total = room.getUnreadNotificationCount(NotificationCountType.Total);
-  let highlight = room.getUnreadNotificationCount(NotificationCountType.Highlight);
-  let syntheticDotUnread = false;
+  const highlight = room.getUnreadNotificationCount(NotificationCountType.Highlight);
 
   // If our latest notification event is confirmed read, clamp stale non-highlight totals.
   if (userId && total > 0 && highlight === 0) {
@@ -255,19 +254,10 @@ export const getUnreadInfo = (room: Room, options?: UnreadInfoOptions): UnreadIn
     }
   }
 
-  // Fallback for cases where SDK counters are stale/zero but unread-by-receipt state still exists.
-  // Represent as a dot badge (count=0) rather than a numeric badge.
-  if (total === 0 && highlight === 0 && roomHaveUnread(room.client, room)) {
-    highlight = 1;
-    syntheticDotUnread = true;
-  }
-
-  const resolvedTotal = syntheticDotUnread ? total : Math.max(total, highlight);
-
   return {
     roomId: room.roomId,
     highlight,
-    total: resolvedTotal,
+    total: Math.max(total, highlight),
   };
 };
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -272,7 +272,10 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
-      const focusedClient = clientList.find((client): client is WindowClient => 'focus' in client);
+      // Prefer a visible (foreground) tab; fall back to any open window client.
+      const focusedClient =
+        clientList.find((c) => c.visibilityState === 'visible') ??
+        clientList.find((c): c is WindowClient => 'focus' in c);
       if (focusedClient) {
         return focusedClient.focus().then(() => {
           postMessageToClient(focusedClient);

--- a/src/sw/pushNotification.ts
+++ b/src/sw/pushNotification.ts
@@ -128,32 +128,17 @@ export const createPushNotifications = (
     await showNotificationWithData('New Invitation', body, data, resolveSilent(pushData?.silent));
   };
 
-  const fallbackNotification = async (pushData: any) => {
-    const body = pushData?.content?.body;
-    let title;
-    if (body) {
-      title = pushData?.sender_display_name
-        ? `${pushData.sender_display_name}${pushData?.room_name ? ` in ${pushData.room_name}` : ''}`
-        : 'New Notification';
-    } else {
-      title = 'You have a new Notification';
-    }
-    const data = {
-      type: pushData?.type,
-      room_id: pushData?.room_id,
-      event_id: pushData?.event_id,
-      user_id: pushData?.user_id,
-      timestamp: Date.now(),
-      ...pushData.data,
-    };
-    await showNotificationWithData(title, body, data, resolveSilent(pushData?.silent));
-  };
+  const isLoudByRule = (pushData: any): boolean => Boolean(pushData?.tweaks?.sound);
 
   const handlePushNotificationPushData = async (pushData: any) => {
     const eventType = pushData?.type as EventType | undefined;
     if (!eventType) {
       console.warn('no event type');
     }
+
+    // Only fire OS notifications for loud-rule events (tweaks.sound present).
+    // Silent-rule events only update the unread badge via the Matrix client sync.
+    if (!isLoudByRule(pushData)) return;
 
     switch (eventType) {
       case EventType.RoomMessage:
@@ -169,8 +154,6 @@ export const createPushNotifications = (
         // no voip support in app anyway
         break;
     }
-
-    return fallbackNotification(pushData);
   };
 
   return { handlePushNotificationPushData };

--- a/src/sw/pushNotification.ts
+++ b/src/sw/pushNotification.ts
@@ -29,11 +29,18 @@ export const createPushNotifications = (
     icon?: string,
     badge?: string
   ) => {
+    const roomId: string | undefined = data?.room_id;
+    // Group by room so new messages in the same room replace the previous
+    // notification rather than stacking individually. renotify: true ensures
+    // the user is still alerted when the existing tag is replaced.
+    const tag = roomId ? `room-${roomId}` : (data?.event_id ?? 'Cinny');
+    const renotify = !!roomId;
     await self.registration.showNotification(title, {
       body,
       icon: icon ?? DEFAULT_NOTIFICATION_ICON,
       badge: badge ?? DEFAULT_NOTIFICATION_BADGE,
-      tag: data?.event_id ?? 'Cinny',
+      tag,
+      renotify,
       silent,
       data,
     });

--- a/src/sw/pushNotification.ts
+++ b/src/sw/pushNotification.ts
@@ -35,7 +35,9 @@ export const createPushNotifications = (
     // the user is still alerted when the existing tag is replaced.
     const tag = roomId ? `room-${roomId}` : (data?.event_id ?? 'Cinny');
     const renotify = !!roomId;
-    await self.registration.showNotification(title, {
+    // `renotify` is a valid Web API property absent from TypeScript's NotificationOptions type.
+    // Build the options object separately to avoid the excess-property check, then cast.
+    const notifOptions = {
       body,
       icon: icon ?? DEFAULT_NOTIFICATION_ICON,
       badge: badge ?? DEFAULT_NOTIFICATION_BADGE,
@@ -43,7 +45,8 @@ export const createPushNotifications = (
       renotify,
       silent,
       data,
-    });
+    };
+    await self.registration.showNotification(title, notifOptions as NotificationOptions);
   };
 
   const handleRoomMessageNotification = async (pushData: any) => {

--- a/src/sw/pushNotification.ts
+++ b/src/sw/pushNotification.ts
@@ -150,13 +150,15 @@ export const createPushNotifications = (
     switch (eventType) {
       case EventType.RoomMessage:
       case EventType.Sticker:
-        return handleRoomMessageNotification(pushData);
+        await handleRoomMessageNotification(pushData);
+        break;
       case EventType.RoomMessageEncrypted:
-        return handleEncryptedMessageNotification(pushData);
+        await handleEncryptedMessageNotification(pushData);
+        break;
       case EventType.RoomMember:
         if (!(pushData?.content?.membership === 'invite')) break;
-        return handleInvitationNotification(pushData);
-
+        await handleInvitationNotification(pushData);
+        break;
       default:
         // no voip support in app anyway
         break;


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Changes:
- Notification click opens the right tab — the service worker now prefers a visible/foreground tab over any background tab when routing a notification click.
- Silent push rules produce no OS notification — the SW now checks tweaks.sound before showing a notification, suppressing OS alerts for silent-rule events (e.g. "all messages" rooms).
- Background session notifications fixed — clients now start processing events in Prepared and Catchup states, not just
- Syncing. Settings are read via refs to avoid stale closures. Background sessions now start when either in-app notifications or push is enabled.
- Active session notifications fixed — restructured the visible/hidden/mobile routing logic so the in-app path correctly handles the visible case. Silent-rule events no longer trigger in-app sound or OS popups. Session-switch race condition on notification click resolved.
- Push notifications grouped by room — successive messages in the same room replace the previous notification (tag: room-{id}, renotify: true) instead of stacking.

Fixes #114 

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
