### PR TITLE
fix consistency of room naming of dms when a nickname for the user is set

### DIFF
--- a/src/app/hooks/useRoomMeta.ts
+++ b/src/app/hooks/useRoomMeta.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { RoomJoinRulesEventContent, Room, RoomEvent, RoomStateEvent } from '$types/matrix-sdk';
 import { StateEvent } from '$types/matrix/room';
 import { useStateEvent } from './useStateEvent';
+import { useNickname } from './useNickname';
 
 export const useRoomAvatar = (room: Room, dm?: boolean): string | undefined => {
   const avatarEvent = useStateEvent(room, StateEvent.RoomAvatar);
@@ -16,6 +17,8 @@ export const useRoomAvatar = (room: Room, dm?: boolean): string | undefined => {
 };
 
 export const useRoomName = (room: Room): string => {
+  const dmUserId = room.guessDMUserId();
+  const dmNickname = useNickname(dmUserId || '');
   const [name, setName] = useState(room.name);
 
   useEffect(() => {
@@ -24,8 +27,10 @@ export const useRoomName = (room: Room): string => {
         room.recalculate();
       }
 
-      setName((prev) => (prev !== room.name ? room.name : prev));
+      const nextName = dmNickname ?? room.name;
+      setName((prev) => (prev !== nextName ? nextName : prev));
     };
+
     updateName();
 
     room.on(RoomEvent.Name, updateName);
@@ -35,7 +40,7 @@ export const useRoomName = (room: Room): string => {
       room.removeListener(RoomEvent.Name, updateName);
       room.removeListener(RoomStateEvent.Members, updateName);
     };
-  }, [room]);
+  }, [room, dmNickname]);
 
   return name;
 };


### PR DESCRIPTION
Also use the nickname for the user in the room header for more consistency

<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I saw the neat feature of giving people nicknames and noticed that the room name of a dm still is the non-nickname-room name. I wanted to fix this for more consistency.

### Without the change (the version currently [deployed](https://app.sable.moe))

<img width="1091" height="730" alt="image" src="https://github.com/user-attachments/assets/8a3bd0d6-b0eb-424a-8f3d-363d958df778" />


#### With the change

<img width="1086" height="813" alt="image" src="https://github.com/user-attachments/assets/2fd6a6ab-ad77-4e7e-8464-2713077bc8da" />


Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
