### PR TITLE
fix: notification delivery, account switching, and unread count toggle

### DIFF
--- a/src/app/components/unread-badge/UnreadBadge.tsx
+++ b/src/app/components/unread-badge/UnreadBadge.tsx
@@ -1,6 +1,8 @@
 import { CSSProperties, ReactNode } from 'react';
 import { Box, Badge, toRem, Text } from 'folds';
 import { millify } from '$plugins/millify';
+import { useSetting } from '$state/hooks/settings';
+import { settingsAtom } from '$state/settings';
 
 type UnreadBadgeProps = {
   highlight?: boolean;
@@ -18,15 +20,17 @@ export function UnreadBadgeCenter({ children }: { children: ReactNode }) {
 }
 
 export function UnreadBadge({ highlight, count }: UnreadBadgeProps) {
+  const [showCounts] = useSetting(settingsAtom, 'showUnreadCounts');
+  const showNumber = showCounts && count > 0;
   return (
     <Badge
       variant={highlight ? 'Success' : 'Secondary'}
-      size={count > 0 ? '400' : '200'}
+      size={showNumber ? '400' : '200'}
       fill="Solid"
       radii="Pill"
       outlined={false}
     >
-      {count > 0 && (
+      {showNumber && (
         <Text as="span" size="L400">
           {millify(count)}
         </Text>

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -899,11 +899,18 @@ export function RoomTimeline({
     )
   );
 
+  // Keep a stable ref so timeline state updates (new messages arriving) don't
+  // cause handleOpenEvent to rebuild and re-trigger this effect, yanking the
+  // user back to the notification event on every incoming message.
+  // We only want to scroll once per unique eventId value.
+  const handleOpenEventRef = useRef(handleOpenEvent);
+  handleOpenEventRef.current = handleOpenEvent;
+
   useEffect(() => {
     if (eventId) {
-      handleOpenEvent(eventId);
+      handleOpenEventRef.current(eventId);
     }
-  }, [eventId, handleOpenEvent]);
+  }, [eventId]); // handleOpenEvent intentionally omitted — use ref above
 
   // Scroll to bottom on initial timeline load
   useLayoutEffect(() => {

--- a/src/app/features/settings/cosmetics/Cosmetics.tsx
+++ b/src/app/features/settings/cosmetics/Cosmetics.tsx
@@ -171,6 +171,7 @@ function IdentityCosmetics() {
   );
   const [uniformIcons, setUniformIcons] = useSetting(settingsAtom, 'uniformIcons');
   const [rightBubbles, setRightBubbles] = useSetting(settingsAtom, 'useRightBubbles');
+  const [showUnreadCounts, setShowUnreadCounts] = useSetting(settingsAtom, 'showUnreadCounts');
 
   return (
     <Box direction="Column" gap="100">
@@ -216,6 +217,15 @@ function IdentityCosmetics() {
           title="Right Aligned Bubbles"
           description="When using bubble layout, have your bubbles right aligned."
           after={<Switch variant="Primary" value={rightBubbles} onChange={setRightBubbles} />}
+        />
+      </SequenceCard>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Show Unread Counts"
+          description="Display the number of unread messages on room and sidebar badges."
+          after={
+            <Switch variant="Primary" value={showUnreadCounts} onChange={setShowUnreadCounts} />
+          }
         />
       </SequenceCard>
     </Box>

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -327,6 +327,7 @@ function PageZoomInput() {
 }
 export function Appearance() {
   const [twitterEmoji, setTwitterEmoji] = useSetting(settingsAtom, 'twitterEmoji');
+  const [showUnreadCounts, setShowUnreadCounts] = useSetting(settingsAtom, 'showUnreadCounts');
 
   return (
     <Box direction="Column" gap="700">
@@ -345,6 +346,15 @@ export function Appearance() {
 
         <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
           <SettingTile title="Page Zoom" after={<PageZoomInput />} />
+        </SequenceCard>
+        <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+          <SettingTile
+            title="Show Unread Counts"
+            description="Display the number of unread messages on room and sidebar badges."
+            after={
+              <Switch variant="Primary" value={showUnreadCounts} onChange={setShowUnreadCounts} />
+            }
+          />
         </SequenceCard>
       </Box>
     </Box>

--- a/src/app/hooks/useNotificationJumper.ts
+++ b/src/app/hooks/useNotificationJumper.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import { SyncState, ClientEvent } from '$types/matrix-sdk';
 import { activeSessionIdAtom, pendingNotificationAtom } from '../state/sessions';
@@ -14,30 +14,42 @@ export function NotificationJumper() {
   const { navigateRoom } = useRoomNavigate();
   const log = createLogger('NotificationJumper');
 
+  // Set true the moment we fire navigateRoom. Only reset when `pending` changes
+  // to a new value (via the effect below). Do NOT reset inside performJump itself:
+  // setPending(null) is async — resetting here creates a window where atom/render
+  // churn re-calls performJump (from the ClientEvent.Room listener or effect
+  // re-runs) before React has committed the null, causing repeated navigation.
+  const jumpingRef = useRef(false);
+
   const performJump = useCallback(() => {
-    if (!pending) return;
+    if (!pending || jumpingRef.current) return;
     if (pending.targetSessionId && pending.targetSessionId !== activeSessionId) {
-      log.log('waiting for target session...', {
+      log.log('waiting for target session atom...', {
         targetSessionId: pending.targetSessionId,
         activeSessionId,
       });
       return;
     }
 
-    const isSyncing = mx.getSyncState() === SyncState.Syncing;
+    // The mx client context may lag one render behind the atom — wait until it catches up.
+    if (pending.targetSessionId && mx.getUserId() !== pending.targetSessionId) {
+      log.log('waiting for mx client to switch to target session...', {
+        targetSessionId: pending.targetSessionId,
+        currentUserId: mx.getUserId(),
+      });
+      return;
+    }
 
+    const isSyncing = mx.getSyncState() === SyncState.Syncing;
     const room = mx.getRoom(pending.roomId);
     const isJoined = room?.getMyMembership() === 'join';
 
     if (isSyncing && isJoined) {
       log.log('jumping to:', pending.roomId);
-
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          navigateRoom(pending.roomId, pending.eventId);
-          setPending(null);
-        });
-      });
+      jumpingRef.current = true;
+      navigateRoom(pending.roomId, pending.eventId);
+      setPending(null);
+      // jumpingRef stays true until pending changes — see effect below.
     } else {
       log.log('still waiting for room data...', {
         isSyncing,
@@ -47,27 +59,38 @@ export function NotificationJumper() {
     }
   }, [pending, activeSessionId, mx, navigateRoom, setPending, log]);
 
+  // Reset the guard only when pending is replaced (new notification or cleared).
+  useEffect(() => {
+    jumpingRef.current = false;
+  }, [pending]);
+
+  // Keep a stable ref to the latest performJump so that the listeners below
+  // always invoke the current version without adding performJump to their dep
+  // arrays. Adding performJump as a dep causes the effect to re-run (and call
+  // performJump again) on every atom change during an account switch — that is
+  // the second source of repeated navigation.
+  const performJumpRef = useRef(performJump);
+  performJumpRef.current = performJump;
+
   useSyncState(
     mx,
-    useCallback(
-      (current) => {
-        if (current === SyncState.Syncing) performJump();
-      },
-      [performJump]
-    )
+    // Stable callback — reads from ref, so useSyncState never re-registers.
+    useCallback((current) => {
+      if (current === SyncState.Syncing) performJumpRef.current();
+    }, [])
   );
 
   useEffect(() => {
     if (!pending) return undefined;
 
-    const onRoom = () => performJump();
+    const onRoom = () => performJumpRef.current();
     mx.on(ClientEvent.Room, onRoom);
-    performJump();
+    performJumpRef.current();
 
     return () => {
       mx.removeListener(ClientEvent.Room, onRoom);
     };
-  }, [pending, mx, performJump]);
+  }, [pending, mx]); // performJump intentionally omitted — use ref above
 
   return null;
 }

--- a/src/app/pages/Router.tsx
+++ b/src/app/pages/Router.tsx
@@ -55,6 +55,7 @@ import {
   getSpaceLobbyPath,
 } from './pathUtils';
 import { ClientBindAtoms, ClientLayout, ClientRoot } from './client';
+import { HandleNotificationClick, ClientNonUIFeatures } from './client/ClientNonUIFeatures';
 import { Home, HomeRouteRoomProvider, HomeSearch } from './client/home';
 import { Direct, DirectCreate, DirectRouteRoomProvider } from './client/direct';
 import { RouteSpaceProvider, Space, SpaceRouteRoomProvider, SpaceSearch } from './client/space';
@@ -65,7 +66,6 @@ import { WelcomePage } from './client/WelcomePage';
 import { SidebarNav } from './client/SidebarNav';
 import { MobileFriendlyPageNav, MobileFriendlyClientNav } from './MobileFriendly';
 import { ClientInitStorageAtom } from './client/ClientInitStorageAtom';
-import { ClientNonUIFeatures } from './client/ClientNonUIFeatures';
 import { AuthRouteThemeManager, UnAuthRouteThemeManager } from './ThemeManager';
 import { ClientRoomsNotificationPreferences } from './client/ClientRoomsNotificationPreferences';
 import { HomeCreateRoom } from './client/home/CreateRoom';
@@ -141,6 +141,10 @@ export const createRouter = (clientConfig: ClientConfig, screenSize: ScreenSize)
         }}
         element={
           <AuthRouteThemeManager>
+            {/* HandleNotificationClick must live outside ClientRoot's loading gate so
+                SW notification-click postMessages are never dropped during client
+                reloads (e.g., account switches). It only needs navigate + Jotai atoms. */}
+            <HandleNotificationClick />
             <ClientRoot>
               <ClientInitStorageAtom>
                 <ClientRoomsNotificationPreferences>

--- a/src/app/pages/client/BackgroundNotifications.tsx
+++ b/src/app/pages/client/BackgroundNotifications.tsx
@@ -10,12 +10,7 @@ import {
   PushProcessor,
 } from '$types/matrix-sdk';
 import { useAtomValue, useSetAtom } from 'jotai';
-import {
-  sessionsAtom,
-  activeSessionIdAtom,
-  Session,
-  pendingNotificationAtom,
-} from '$state/sessions';
+import { sessionsAtom, activeSessionIdAtom, Session, sessionsHighlightAtom } from '$state/sessions';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
 import { getMxIdLocalPart, mxcUrlToHttp } from '$utils/matrix';
@@ -29,16 +24,16 @@ import { NotificationType, StateEvent } from '$types/matrix/room';
 import { createLogger } from '$utils/debug';
 import LogoSVG from '$public/res/svg/cinny.svg';
 import { nicknamesAtom } from '$state/nicknames';
-import { useMatrixClient } from '$hooks/useMatrixClient';
 import {
   buildRoomMessageNotification,
   resolveNotificationPreviewText,
 } from '$utils/notificationStyle';
-import { mobileOrTablet } from '$utils/user-agent';
 import { startClient, stopClient } from '$client/initMatrix';
 import { useClientConfig } from '$hooks/useClientConfig';
 
 const log = createLogger('BackgroundNotifications');
+const isClientReadyForNotifications = (state: SyncState | string | null): boolean =>
+  state === SyncState.Prepared || state === SyncState.Syncing || state === SyncState.Catchup;
 
 const startBackgroundClient = async (
   session: Session,
@@ -66,12 +61,12 @@ const startBackgroundClient = async (
 const waitForSync = (mx: MatrixClient): Promise<void> =>
   new Promise((resolve) => {
     const state = mx.getSyncState();
-    if (state === SyncState.Syncing) {
+    if (isClientReadyForNotifications(state)) {
       resolve();
       return;
     }
     const onSync = (newState: SyncState) => {
-      if (newState === SyncState.Syncing) {
+      if (isClientReadyForNotifications(newState)) {
         mx.removeListener(ClientEvent.Sync, onSync);
         resolve();
       }
@@ -83,7 +78,6 @@ export function BackgroundNotifications() {
   const clientConfig = useClientConfig();
   const sessions = useAtomValue(sessionsAtom);
   const activeSessionId = useAtomValue(activeSessionIdAtom);
-  const setActiveSessionId = useSetAtom(activeSessionIdAtom);
   const [showNotifications] = useSetting(settingsAtom, 'useInAppNotifications');
   const [usePushNotifications] = useSetting(settingsAtom, 'usePushNotifications');
   const [notificationSound] = useSetting(settingsAtom, 'isNotificationSounds');
@@ -92,14 +86,22 @@ export function BackgroundNotifications() {
     settingsAtom,
     'showMessageContentInEncryptedNotifications'
   );
-  const forcePushOnMobile = usePushNotifications && mobileOrTablet();
-  const activeMx = useMatrixClient();
+  const shouldRunBackgroundNotifications = showNotifications || usePushNotifications;
   const nicknames = useAtomValue(nicknamesAtom);
   const nicknamesRef = useRef(nicknames);
   nicknamesRef.current = nicknames;
+  // Refs so handleTimeline callbacks always read current settings without stale closures
+  const showNotificationsRef = useRef(showNotifications);
+  showNotificationsRef.current = showNotifications;
+  const notificationSoundRef = useRef(notificationSound);
+  notificationSoundRef.current = notificationSound;
+  const showMessageContentRef = useRef(showMessageContent);
+  showMessageContentRef.current = showMessageContent;
+  const showEncryptedMessageContentRef = useRef(showEncryptedMessageContent);
+  showEncryptedMessageContentRef.current = showEncryptedMessageContent;
   const clientsRef = useRef<Map<string, MatrixClient>>(new Map());
   const notifiedEventsRef = useRef<Set<string>>(new Set());
-  const setPending = useSetAtom(pendingNotificationAtom);
+  const setHighlights = useSetAtom(sessionsHighlightAtom);
 
   const inactiveSessions = sessions.filter(
     (s) => s.userId !== (activeSessionId ?? sessions[0]?.userId)
@@ -116,36 +118,48 @@ export function BackgroundNotifications() {
     badge?: string;
     /** If `true` the notification plays no sound. */
     silent?: boolean;
-    /** Callback when the user taps/clicks the notification. */
-    onClick?: () => void;
+    /** Arbitrary payload attached to the notification.
+     * Must include { type, room_id, event_id, user_id } so the SW notificationclick
+     * handler can route the tap through HandleNotificationClick for account switching. */
+    data?: unknown;
   }
 
   useEffect(() => {
-    if (forcePushOnMobile) return undefined;
-    if (!showNotifications) return undefined;
+    if (!shouldRunBackgroundNotifications) return undefined;
 
     const { current } = clientsRef;
     const activeIds = new Set(inactiveSessions.map((s) => s.userId));
 
-    async function sendNotification(opts: NotifyOptions): Promise<Notification | undefined> {
+    async function sendNotification(opts: NotifyOptions): Promise<void> {
+      // Prefer ServiceWorkerRegistration.showNotification so that taps are handled
+      // by the SW notificationclick event. This routes through HandleNotificationClick
+      // (postMessage path) which does the account switch + deep link reliably on all
+      // platforms including iOS where window.Notification onclick is not fired.
+      if ('serviceWorker' in navigator) {
+        try {
+          const reg = await navigator.serviceWorker.ready;
+          await reg.showNotification(opts.title, {
+            body: opts.body,
+            icon: opts.icon,
+            badge: opts.badge,
+            silent: opts.silent ?? false,
+            data: opts.data,
+          } as NotificationOptions);
+          return;
+        } catch {
+          // Fall through to window.Notification if SW registration fails.
+        }
+      }
       if ('Notification' in window && window.Notification.permission === 'granted') {
-        const noti = new window.Notification(opts.title, {
+        // eslint-disable-next-line no-new
+        new window.Notification(opts.title, {
           icon: opts.icon,
           badge: opts.badge,
           body: opts.body,
           silent: opts.silent ?? false,
+          data: opts.data,
         });
-        if (opts.onClick) {
-          const cb = opts.onClick;
-          noti.onclick = () => {
-            cb();
-            noti.close();
-          };
-        }
-        return noti;
       }
-
-      return undefined;
     }
 
     current.forEach((mx, userId) => {
@@ -153,6 +167,12 @@ export function BackgroundNotifications() {
         log.log('stopping background client for', userId);
         stopClient(mx);
         current.delete(userId);
+        // Clear the highlight badge when this session is no longer a background account.
+        setHighlights((prev) => {
+          const next = { ...prev };
+          delete next[userId];
+          return next;
+        });
       }
     });
 
@@ -176,18 +196,17 @@ export function BackgroundNotifications() {
             removed: boolean,
             data: { liveEvent: boolean }
           ) => {
-            if (mx.getSyncState() !== 'SYNCING') return;
+            if (!isClientReadyForNotifications(mx.getSyncState())) return;
             if (!room || !data?.liveEvent || room.isSpaceRoom()) return;
             if (!isNotificationEvent(mEvent)) return;
 
             const notifType = getNotificationType(mx, room.roomId);
             if (notifType === NotificationType.Mute) return;
 
-            const activeRoom = activeMx.getRoom(room.roomId);
-            if (activeRoom?.getMyMembership() === 'join') return;
-
             const eventId = mEvent.getId();
-            if (!eventId || notifiedEventsRef.current.has(eventId)) return;
+            if (!eventId) return;
+            const dedupeId = `${session.userId}:${eventId}`;
+            if (notifiedEventsRef.current.has(dedupeId)) return;
 
             const sender = mEvent.getSender();
             if (!sender || sender === mx.getUserId()) return;
@@ -206,28 +225,47 @@ export function BackgroundNotifications() {
               ? (mxcUrlToHttp(mx, avatarMxc, false, 96, 96, 'crop') ?? undefined)
               : LogoSVG;
 
-            const isHighlight = pushActions.tweaks?.highlight === true;
+            const loudByRule = Boolean(pushActions.tweaks?.sound);
             const isEncryptedRoom = !!getStateEvent(room, StateEvent.RoomEncryption);
 
-            notifiedEventsRef.current.add(eventId);
+            notifiedEventsRef.current.add(dedupeId);
             // Cap the set so it doesn't grow unbounded
             if (notifiedEventsRef.current.size > 200) {
               const first = notifiedEventsRef.current.values().next().value;
               if (first) notifiedEventsRef.current.delete(first);
             }
 
+            // Track highlight count for the account switcher badge.
+            if (pushActions.tweaks?.highlight) {
+              setHighlights((prev) => ({
+                ...prev,
+                [session.userId]: (prev[session.userId] ?? 0) + 1,
+              }));
+            }
+
+            // This component handles ONLY background (inactive) accounts.
+            // SW push covers the active account when the app is backgrounded.
+            // When the page is hidden, iOS suspends JS entirely — nothing to do here.
+            // Only show an in-app notification when the user is actively looking at the app.
+            if (document.visibilityState !== 'visible') return;
+
+            // Respect in-app notification setting (read from ref to avoid stale closure)
+            if (!showNotificationsRef.current) return;
+
             const notificationPayload = buildRoomMessageNotification({
-              roomName: room.name ?? 'Unknown',
+              roomName: room.name ?? room.getCanonicalAlias() ?? room.roomId,
               roomAvatar,
               username: senderName,
+              recipientId: session.userId,
               previewText: resolveNotificationPreviewText({
                 content: mEvent.getContent(),
                 eventType: mEvent.getType(),
                 isEncryptedRoom,
-                showMessageContent,
-                showEncryptedMessageContent,
+                showMessageContent: showMessageContentRef.current,
+                showEncryptedMessageContent: showEncryptedMessageContentRef.current,
               }),
-              silent: !notificationSound || !isHighlight,
+              // Play sound only if the push rule requests it and the user has sounds enabled.
+              silent: !notificationSoundRef.current || !loudByRule,
               eventId,
               data: {
                 type: mEvent.getType(),
@@ -243,11 +281,7 @@ export function BackgroundNotifications() {
               badge: notificationPayload.options.badge,
               body: notificationPayload.options.body,
               silent: notificationPayload.options.silent ?? undefined,
-              onClick: () => {
-                window.focus();
-                setPending({ roomId: room.roomId, eventId, targetSessionId: session.userId });
-                if (session.userId !== activeSessionId) setActiveSessionId(session.userId);
-              },
+              data: notificationPayload.options.data,
             });
           };
 
@@ -262,19 +296,7 @@ export function BackgroundNotifications() {
       current.forEach((mx) => stopClient(mx));
       current.clear();
     };
-  }, [
-    clientConfig.slidingSync,
-    inactiveSessions,
-    forcePushOnMobile,
-    showNotifications,
-    notificationSound,
-    showMessageContent,
-    showEncryptedMessageContent,
-    activeMx,
-    activeSessionId,
-    setActiveSessionId,
-    setPending,
-  ]);
+  }, [clientConfig.slidingSync, inactiveSessions, shouldRunBackgroundNotifications, setHighlights]);
 
   return null;
 }

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -1,8 +1,8 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { ReactNode, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { EventType, RoomEvent, RoomEventHandlerMap } from '$types/matrix-sdk';
-import { roomToUnreadAtom, unreadEqual, unreadInfoToUnread } from '$state/room/roomToUnread';
+import { EventType, PushProcessor, RoomEvent, RoomEventHandlerMap } from '$types/matrix-sdk';
+import { roomToUnreadAtom } from '$state/room/roomToUnread';
 import LogoSVG from '$public/res/svg/cinny.svg';
 import LogoUnreadSVG from '$public/res/svg/cinny-unread.svg';
 import LogoHighlightSVG from '$public/res/svg/cinny-highlight.svg';
@@ -19,10 +19,9 @@ import {
   getMemberDisplayName,
   getNotificationType,
   getStateEvent,
-  getUnreadInfo,
   isNotificationEvent,
 } from '$utils/room';
-import { NotificationType, StateEvent, UnreadInfo } from '$types/matrix/room';
+import { NotificationType, StateEvent } from '$types/matrix/room';
 import { getMxIdLocalPart, mxcUrlToHttp } from '$utils/matrix';
 import { useSelectedRoom } from '$hooks/router/useSelectedRoom';
 import { useInboxNotificationsSelected } from '$hooks/router/useInbox';
@@ -89,13 +88,24 @@ function FaviconUpdater() {
     }
     try {
       navigator.setAppBadge(total);
-      if (usePushNotifications && total === 0) {
-        registration
-          .getNotifications()
-          .then((pushNotifications) =>
-            pushNotifications.forEach((pushNotification) => pushNotification.close())
-          );
-        navigator.clearAppBadge();
+      if (usePushNotifications) {
+        if (total === 0) {
+          // All rooms read — clear every notification and the badge.
+          registration.getNotifications().then((notifs) => notifs.forEach((n) => n.close()));
+          navigator.clearAppBadge();
+        } else {
+          // Dismiss notifications for individual rooms that are now fully read.
+          registration.getNotifications().then((notifs) => {
+            notifs.forEach((n) => {
+              const notifRoomId = n.data?.room_id;
+              if (!notifRoomId) return;
+              const roomUnread = roomToUnread.get(notifRoomId);
+              if (!roomUnread || (roomUnread.total === 0 && roomUnread.highlight === 0)) {
+                n.close();
+              }
+            });
+          });
+        }
       }
     } catch {
       // Likely Firefox/Gecko-based and doesn't support badging API
@@ -115,7 +125,6 @@ function InviteNotifications() {
   const [showNotifications] = useSetting(settingsAtom, 'useInAppNotifications');
   const [usePushNotifications] = useSetting(settingsAtom, 'usePushNotifications');
   const [notificationSound] = useSetting(settingsAtom, 'isNotificationSounds');
-  const forcePushOnMobile = usePushNotifications && mobileOrTablet();
 
   const notify = useCallback(
     (count: number) => {
@@ -140,16 +149,22 @@ function InviteNotifications() {
   }, []);
 
   useEffect(() => {
-    if (forcePushOnMobile) return;
-    if (usePushNotifications && document.visibilityState !== 'visible') return;
-    if (invites.length > perviousInviteLen && mx.getSyncState() === 'SYNCING') {
-      if (showNotifications && notificationPermission('granted')) {
-        notify(invites.length - perviousInviteLen);
-      }
+    if (invites.length <= perviousInviteLen || mx.getSyncState() !== 'SYNCING') return;
 
-      if (notificationSound) {
-        playSound();
-      }
+    // Page hidden: if push is enabled, SW handles the OS notification. If not, nothing to do.
+    if (document.visibilityState !== 'visible') return;
+
+    // Page is visible — show in-app experience.
+    // On mobile with push: iOS-style — play sound only, no OS notification (SW is silent when
+    // the app is visible on mobile, matching foreground behaviour of native chat apps).
+    // On desktop with push: SW skipped (saw a visible client), so we show the OS notification.
+    // Without push: always show OS notification when page is visible.
+    const isVisibleMobileWithPush = usePushNotifications && mobileOrTablet();
+    if (!isVisibleMobileWithPush && showNotifications && notificationPermission('granted')) {
+      notify(invites.length - perviousInviteLen);
+    }
+    if (notificationSound) {
+      playSound();
     }
   }, [
     mx,
@@ -157,7 +172,6 @@ function InviteNotifications() {
     perviousInviteLen,
     showNotifications,
     usePushNotifications,
-    forcePushOnMobile,
     notificationSound,
     notify,
     playSound,
@@ -174,7 +188,7 @@ function InviteNotifications() {
 function MessageNotifications() {
   const audioRef = useRef<HTMLAudioElement>(null);
   const notifRef = useRef<Notification>();
-  const unreadCacheRef = useRef<Map<string, UnreadInfo>>(new Map());
+  const notifiedEventsRef = useRef<Set<string>>(new Set());
   const mx = useMatrixClient();
   const useAuthentication = useMediaAuthentication();
   const [showNotifications] = useSetting(settingsAtom, 'useInAppNotifications');
@@ -185,7 +199,6 @@ function MessageNotifications() {
     settingsAtom,
     'showMessageContentInEncryptedNotifications'
   );
-  const forcePushOnMobile = usePushNotifications && mobileOrTablet();
   const nicknames = useAtomValue(nicknamesAtom);
   const nicknamesRef = useRef(nicknames);
   nicknamesRef.current = nicknames;
@@ -202,6 +215,7 @@ function MessageNotifications() {
       roomId,
       eventId,
       previewText,
+      silent,
     }: {
       roomName: string;
       roomAvatar?: string;
@@ -209,13 +223,14 @@ function MessageNotifications() {
       roomId: string;
       eventId: string;
       previewText: string;
+      silent: boolean;
     }) => {
       const payload = buildRoomMessageNotification({
         roomName,
         roomAvatar,
         username,
         previewText,
-        silent: true,
+        silent,
         eventId,
       });
       const noti = new window.Notification(payload.title, payload.options);
@@ -240,6 +255,7 @@ function MessageNotifications() {
   }, []);
 
   useEffect(() => {
+    const pushProcessor = new PushProcessor(mx);
     const handleTimelineEvent: RoomEventHandlerMap[RoomEvent.Timeline] = (
       mEvent,
       room,
@@ -247,9 +263,7 @@ function MessageNotifications() {
       removed,
       data
     ) => {
-      if (forcePushOnMobile) return;
       if (mx.getSyncState() !== 'SYNCING') return;
-      if (usePushNotifications && document.visibilityState !== 'visible') return;
       if (document.hasFocus() && (selectedRoomId === room?.roomId || notificationSelected)) return;
 
       if (
@@ -265,19 +279,28 @@ function MessageNotifications() {
       const sender = mEvent.getSender();
       const eventId = mEvent.getId();
       if (!sender || !eventId || mEvent.getSender() === mx.getUserId()) return;
-      const unreadInfo = getUnreadInfo(room);
-      const cachedUnreadInfo = unreadCacheRef.current.get(room.roomId);
-      unreadCacheRef.current.set(room.roomId, unreadInfo);
+      const pushActions = pushProcessor.actionsForEvent(mEvent);
+      if (!pushActions?.notify) return;
+      const loudByRule = Boolean(pushActions.tweaks?.sound);
 
-      if (unreadInfo.total === 0) return;
-      if (
-        cachedUnreadInfo &&
-        unreadEqual(unreadInfoToUnread(cachedUnreadInfo), unreadInfoToUnread(unreadInfo))
-      ) {
-        return;
+      // Deduplicate: never fire the same notification twice for the same event.
+      if (notifiedEventsRef.current.has(eventId)) return;
+      notifiedEventsRef.current.add(eventId);
+      if (notifiedEventsRef.current.size > 200) {
+        const first = notifiedEventsRef.current.values().next().value;
+        if (first) notifiedEventsRef.current.delete(first);
       }
 
-      if (showNotifications && notificationPermission('granted')) {
+      // Page hidden: if push is enabled, SW handles the OS notification. If not, nothing to do.
+      if (document.visibilityState !== 'visible') return;
+
+      // Page is visible — show in-app experience.
+      // On mobile with push: iOS-style — play sound only, no OS notification (SW is silent when
+      // the app is visible on mobile, matching foreground behaviour of native chat apps).
+      // On desktop with push: SW skipped (saw a visible client), so we show the OS notification.
+      // Without push: always show OS notification when page is visible.
+      const isVisibleMobileWithPush = usePushNotifications && mobileOrTablet();
+      if (!isVisibleMobileWithPush && showNotifications && notificationPermission('granted')) {
         const isEncryptedRoom = !!getStateEvent(room, StateEvent.RoomEncryption);
         const avatarMxc =
           room.getAvatarFallbackMember()?.getMxcAvatarUrl() ?? room.getMxcAvatarUrl();
@@ -299,10 +322,12 @@ function MessageNotifications() {
             showMessageContent,
             showEncryptedMessageContent,
           }),
+          // Play sound only if the push rule requests it and the user has sounds enabled.
+          silent: !notificationSound || !loudByRule,
         });
       }
 
-      if (notificationSound) {
+      if (notificationSound && loudByRule) {
         playSound();
       }
     };
@@ -318,7 +343,6 @@ function MessageNotifications() {
     showMessageContent,
     showEncryptedMessageContent,
     usePushNotifications,
-    forcePushOnMobile,
     playSound,
     notify,
     selectedRoomId,
@@ -351,15 +375,17 @@ type ClientNonUIFeaturesProps = {
   children: ReactNode;
 };
 
-function HandleNotificationClick() {
+export function HandleNotificationClick() {
   const navigate = useNavigate();
-  const activeSessionId = useAtomValue(activeSessionIdAtom);
   const setActiveSessionId = useSetAtom(activeSessionIdAtom);
   const setPending = useSetAtom(pendingNotificationAtom);
 
   useEffect(() => {
     const handleNotificationClickEvent = (event: any) => {
-      if (!event.data || !event.source) return;
+      if (!event.data) return;
+      // Note: do NOT guard on event.source — iOS Safari sets it to null for
+      // SW-to-client postMessages (Webkit divergence from spec). The type check
+      // below is the correct way to filter unrelated messages.
       const eventData = event.data;
       if (!(eventData?.type === 'notificationToRoomEvent')) return;
       const messageData = eventData?.message;
@@ -374,9 +400,9 @@ function HandleNotificationClick() {
       switch (eventType) {
         case EventType.RoomMessage:
         case EventType.RoomMessageEncrypted:
-          if (targetSessionId && targetSessionId !== activeSessionId) {
-            setActiveSessionId(targetSessionId);
-          }
+          // Always set the target session — jotai ignores no-ops if already active.
+          // This ensures we never accidentally navigate under the wrong account.
+          if (targetSessionId) setActiveSessionId(targetSessionId);
           setPending({
             roomId: messageData!.room_id,
             eventId: messageData!.event_id,
@@ -385,9 +411,7 @@ function HandleNotificationClick() {
           return;
         case EventType.RoomMember:
           if (!(messageData?.content?.membership === 'invite')) return;
-          if (targetSessionId && targetSessionId !== activeSessionId) {
-            setActiveSessionId(targetSessionId);
-          }
+          if (targetSessionId) setActiveSessionId(targetSessionId);
           navigate(getInboxInvitesPath());
           break;
         default:
@@ -399,7 +423,7 @@ function HandleNotificationClick() {
     return () => {
       navigator.serviceWorker.removeEventListener('message', handleNotificationClickEvent);
     };
-  }, [activeSessionId, navigate, setActiveSessionId, setPending]);
+  }, [navigate, setActiveSessionId, setPending]);
 
   return null;
 }
@@ -415,7 +439,9 @@ function SyncNotificationSettingsWithServiceWorker() {
 
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return;
-    const preferPushOnMobile = usePushNotifications && mobileOrTablet();
+    // preferPushOnMobile=false: SW skips push when page is visible on all devices.
+    // The in-app path handles the visible case (sound on mobile, OS notification on desktop).
+    const preferPushOnMobile = false;
     const payload = {
       type: 'setNotificationSettings' as const,
       notificationSoundEnabled: notificationSound,
@@ -443,7 +469,6 @@ export function ClientNonUIFeatures({ children }: ClientNonUIFeaturesProps) {
       <InviteNotifications />
       <MessageNotifications />
       <BackgroundNotifications />
-      <HandleNotificationClick />
       <SyncNotificationSettingsWithServiceWorker />
       {children}
     </>

--- a/src/app/pages/client/ToRoomEvent.tsx
+++ b/src/app/pages/client/ToRoomEvent.tsx
@@ -1,43 +1,35 @@
-import { useEffect, useState, useCallback } from 'react';
-import { useParams } from 'react-router-dom';
-import { useAtomValue } from 'jotai';
-import { SyncState } from '$types/matrix-sdk';
+import { useEffect } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { useSetAtom } from 'jotai';
+import { activeSessionIdAtom, pendingNotificationAtom } from '$state/sessions';
 
-import { useRoomNavigate } from '../../hooks/useRoomNavigate';
-import { useMatrixClient } from '../../hooks/useMatrixClient';
-import { useSyncState } from '../../hooks/useSyncState';
-import { roomToParentsAtom } from '../../state/room/roomToParents';
-import { mDirectAtom } from '../../state/mDirectList';
-
+// ToRoomEvent handles the /to/:room_id/:event_id route used by the SW when it
+// opens a new window for a push notification (killed-app case) OR by client.navigate()
+// on iOS where postMessage is unreliable after focus().
+//
+// It does NOT navigate itself. Instead it writes to pendingNotificationAtom so
+// that NotificationJumper handles the actual navigation once the correct client
+// is synced. This survives the ClientRoot account-switch reload that happens when
+// setActiveSessionId() changes the active session: ToRoomEvent unmounts as soon
+// as ClientRoot calls navigate(getHomePath()), but the atom value persists and
+// NotificationJumper picks it up once the new client is ready.
 export function ToRoomEvent() {
-  const mx = useMatrixClient();
-  const roomToParents = useAtomValue(roomToParentsAtom);
-  const mDirects = useAtomValue(mDirectAtom);
   const { room_id: roomId, event_id: eventId } = useParams();
-  const { navigateRoom } = useRoomNavigate();
-  const [syncState, setSyncState] = useState<SyncState | null>(mx?.getSyncState() ?? null);
-
-  useSyncState(
-    mx,
-    useCallback((s) => setSyncState(s), [])
-  );
+  const [searchParams] = useSearchParams();
+  const targetUserId = searchParams.get('uid') ?? undefined;
+  const setActiveSessionId = useSetAtom(activeSessionIdAtom);
+  const setPending = useSetAtom(pendingNotificationAtom);
 
   useEffect(() => {
-    if (!roomId || !mx) {
-      return;
-    }
-    if (syncState !== SyncState.Syncing) {
-      return;
-    }
-    if (!roomToParents.size || !mDirects.size) {
-      return;
-    }
-
+    if (!roomId) return;
+    const rid = roomId; // narrowed to string
+    if (targetUserId) setActiveSessionId(targetUserId);
+    setPending({ roomId: rid, eventId, targetSessionId: targetUserId });
+    // Push a clean entry onto history so the back button doesn't return to /to/…
     if (window.history.length <= 2) {
       window.history.pushState({}, '', '/');
     }
-    navigateRoom(roomId, eventId);
-  }, [mx, syncState, roomToParents, mDirects, roomId, eventId, navigateRoom]);
+  }, [roomId, eventId, targetUserId, setActiveSessionId, setPending]);
 
   return null;
 }

--- a/src/app/pages/client/sidebar/AccountSwitcherTab.tsx
+++ b/src/app/pages/client/sidebar/AccountSwitcherTab.tsx
@@ -17,8 +17,14 @@ import {
 import FocusTrap from 'focus-trap-react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
-import { sessionsAtom, activeSessionIdAtom, Session } from '$state/sessions';
-import { SidebarItem, SidebarItemTooltip, SidebarAvatar } from '$components/sidebar';
+import { sessionsAtom, activeSessionIdAtom, Session, sessionsHighlightAtom } from '$state/sessions';
+import {
+  SidebarItem,
+  SidebarItemTooltip,
+  SidebarAvatar,
+  SidebarItemBadge,
+} from '$components/sidebar';
+import { UnreadBadge } from '$components/unread-badge';
 import { UserAvatar } from '$components/user-avatar';
 import { nameInitials } from '$utils/common';
 import { getMxIdLocalPart, mxcUrlToHttp } from '$utils/matrix';
@@ -42,6 +48,7 @@ function AccountRow({
   displayName,
   avatarUrl,
   isBusy,
+  highlightCount,
   onSwitch,
   onSignOut,
 }: {
@@ -50,6 +57,7 @@ function AccountRow({
   displayName?: string;
   avatarUrl?: string;
   isBusy?: boolean;
+  highlightCount?: number;
   onSwitch: (session: Session) => void;
   onSignOut: (session: Session) => void;
 }) {
@@ -77,6 +85,9 @@ function AccountRow({
       }
       after={
         <Box gap="200" alignItems="Center" shrink="No">
+          {!isActive && highlightCount != null && highlightCount > 0 && (
+            <UnreadBadge highlight count={highlightCount} />
+          )}
           {isActive && (
             <Icon size="200" src={Icons.Check} style={{ color: 'var(--mx-c-success)' }} />
           )}
@@ -126,6 +137,7 @@ export function AccountSwitcherTab() {
   const sessions = useAtomValue(sessionsAtom);
   const [activeSessionId, setActiveSessionId] = useAtom(activeSessionIdAtom);
   const setSessions = useSetAtom(sessionsAtom);
+  const [sessionHighlights, setSessionHighlights] = useAtom(sessionsHighlightAtom);
   const useAuthentication = useMediaAuthentication();
 
   const [menuAnchor, setMenuAnchor] = useState<RectCords>();
@@ -161,8 +173,14 @@ export function AccountSwitcherTab() {
       setMenuAnchor(undefined);
       navigate(getHomePath(), { replace: true });
       setActiveSessionId(session.userId);
+      // Clear the highlight badge for the account we're switching to.
+      setSessionHighlights((prev) => {
+        const next = { ...prev };
+        delete next[session.userId];
+        return next;
+      });
     },
-    [navigate, setActiveSessionId]
+    [navigate, setActiveSessionId, setSessionHighlights]
   );
 
   const handleSignOut = useCallback(
@@ -219,6 +237,10 @@ export function AccountSwitcherTab() {
     getMxIdLocalPart(activeSession?.userId ?? '') ?? activeSession?.userId ?? '';
   const label = activeDisplayName ?? activeLocalPart;
 
+  const inactiveHighlightTotal = sessions
+    .filter((s) => s.userId !== (activeSessionId ?? sessions[0]?.userId))
+    .reduce((sum, s) => sum + (sessionHighlights[s.userId] ?? 0), 0);
+
   if (!activeSession) return null;
 
   return (
@@ -240,6 +262,11 @@ export function AccountSwitcherTab() {
           </SidebarAvatar>
         )}
       </SidebarItemTooltip>
+      {inactiveHighlightTotal > 0 && (
+        <SidebarItemBadge hasCount>
+          <UnreadBadge highlight count={inactiveHighlightTotal} />
+        </SidebarItemBadge>
+      )}
 
       <PopOut
         anchor={menuAnchor}
@@ -283,6 +310,7 @@ export function AccountSwitcherTab() {
                       displayName={rowDisplayName}
                       avatarUrl={rowAvatarUrl}
                       isBusy={busyUserIds.has(session.userId)}
+                      highlightCount={sessionHighlights[session.userId]}
                       onSwitch={handleSwitch}
                       onSignOut={handleSignOut}
                     />

--- a/src/app/state/room/roomToUnread.ts
+++ b/src/app/state/room/roomToUnread.ts
@@ -10,6 +10,7 @@ import {
   ReceiptContent,
   ReceiptType,
   EventType,
+  ClientEvent,
 } from '$types/matrix-sdk';
 import { useCallback, useEffect, useRef } from 'react';
 import {
@@ -32,7 +33,6 @@ import { useSyncState } from '$hooks/useSyncState';
 import { useRoomsNotificationPreferencesContext } from '$hooks/useRoomsNotificationPreferences';
 import { getClientSyncDiagnostics } from '$client/initMatrix';
 import { roomToParentsAtom } from './roomToParents';
-import { mDirectAtom } from '../mDirectList';
 
 export type RoomToUnreadAction =
   | {
@@ -123,14 +123,13 @@ const baseRoomToUnread = atom<RoomToUnread>(new Map());
 export const roomToUnreadAtom = atom<RoomToUnread, [RoomToUnreadAction], undefined>(
   (get) => get(baseRoomToUnread),
   (get, set, action) => {
-    const dmRoomIds = get(mDirectAtom);
-    const getEffectiveParents = (roomId: string): Set<string> =>
-      dmRoomIds.has(roomId) ? new Set() : getAllParents(get(roomToParentsAtom), roomId);
+    const allParentsOf = (roomId: string): Set<string> =>
+      getAllParents(get(roomToParentsAtom), roomId);
 
     if (action.type === 'RESET') {
       const draftRoomToUnread: RoomToUnread = new Map();
       action.unreadInfos.forEach((unreadInfo) => {
-        putUnreadInfo(draftRoomToUnread, getEffectiveParents(unreadInfo.roomId), unreadInfo);
+        putUnreadInfo(draftRoomToUnread, allParentsOf(unreadInfo.roomId), unreadInfo);
       });
       set(baseRoomToUnread, draftRoomToUnread);
       return;
@@ -144,7 +143,7 @@ export const roomToUnreadAtom = atom<RoomToUnread, [RoomToUnreadAction], undefin
             produce(get(baseRoomToUnread), (draftRoomToUnread) =>
               deleteUnreadInfo(
                 draftRoomToUnread,
-                getEffectiveParents(unreadInfo.roomId),
+                allParentsOf(unreadInfo.roomId),
                 unreadInfo.roomId
               )
             )
@@ -154,14 +153,14 @@ export const roomToUnreadAtom = atom<RoomToUnread, [RoomToUnreadAction], undefin
       }
       const currentUnread = get(baseRoomToUnread).get(unreadInfo.roomId);
       if (currentUnread && unreadEqual(currentUnread, unreadInfoToUnread(unreadInfo))) {
-        // Do not update if unread data has not changes
+        // Do not update if unread data has not changed
         // like total & highlight
         return;
       }
       set(
         baseRoomToUnread,
         produce(get(baseRoomToUnread), (draftRoomToUnread) =>
-          putUnreadInfo(draftRoomToUnread, getEffectiveParents(unreadInfo.roomId), unreadInfo)
+          putUnreadInfo(draftRoomToUnread, allParentsOf(unreadInfo.roomId), unreadInfo)
         )
       );
       return;
@@ -170,7 +169,7 @@ export const roomToUnreadAtom = atom<RoomToUnread, [RoomToUnreadAction], undefin
       set(
         baseRoomToUnread,
         produce(get(baseRoomToUnread), (draftRoomToUnread) =>
-          deleteUnreadInfo(draftRoomToUnread, getEffectiveParents(action.roomId), action.roomId)
+          deleteUnreadInfo(draftRoomToUnread, allParentsOf(action.roomId), action.roomId)
         )
       );
     }
@@ -328,6 +327,25 @@ export const useBindRoomToUnreadAtom = (mx: MatrixClient, unreadAtom: typeof roo
       mx.removeListener(RoomEvent.MyMembership, handleMembershipChange);
     };
   }, [mx, setUnreadAtom]);
+
+  // Seed badge state immediately when a room is first registered with the client
+  // (e.g. after joining or receiving an invite that gets auto-accepted).
+  // This avoids the brief window after refresh where badges are invisible until
+  // the next timeline event arrives. Notifications are NOT triggered here —
+  // ClientNonUIFeatures handles live notification pop-ups via its own listener.
+  useEffect(() => {
+    const handleRoomAdded = (room: Room) => {
+      if (room.isSpaceRoom() || room.getMyMembership() !== Membership.Join) return;
+      const unreadInfo = getUnreadInfo(room, { applyFixup: shouldApplyUnreadFixup() });
+      if (unreadInfo.total > 0 || unreadInfo.highlight > 0) {
+        setUnreadAtom({ type: 'PUT', unreadInfo });
+      }
+    };
+    mx.on(ClientEvent.Room, handleRoomAdded as (room: Room) => void);
+    return () => {
+      mx.removeListener(ClientEvent.Room, handleRoomAdded as (room: Room) => void);
+    };
+  }, [mx, setUnreadAtom, shouldApplyUnreadFixup]);
 
   useEffect(
     () => () => {

--- a/src/app/state/sessions.ts
+++ b/src/app/state/sessions.ts
@@ -165,8 +165,15 @@ export const activeSessionIdAtom = atom<string | undefined, [string | undefined]
 
 export type PendingNotification = {
   roomId: string;
-  eventId: string;
+  eventId?: string;
   targetSessionId?: string;
 };
 
 export const pendingNotificationAtom = atom<PendingNotification | null>(null);
+
+/**
+ * Tracks the count of highlight-level (mention/keyword) notifications received
+ * by each background (inactive) session. Keyed by userId.
+ * Cleared when a session becomes active or is signed out.
+ */
+export const sessionsHighlightAtom = atom<Record<string, number>>({});

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -67,6 +67,7 @@ export interface Settings {
   rightSwipeAction: RightSwipeAction;
   hideMembershipInReadOnly: boolean;
   useRightBubbles: boolean;
+  showUnreadCounts: boolean;
 }
 
 const defaultSettings: Settings = {
@@ -120,6 +121,7 @@ const defaultSettings: Settings = {
   rightSwipeAction: RightSwipeAction.Reply,
   hideMembershipInReadOnly: true,
   useRightBubbles: false,
+  showUnreadCounts: true,
 };
 
 export const getSettings = () => {

--- a/src/app/utils/notificationStyle.ts
+++ b/src/app/utils/notificationStyle.ts
@@ -11,6 +11,10 @@ type RoomMessageNotificationInput = {
   silent?: boolean;
   eventId?: string;
   data?: unknown;
+  /** Matrix user ID of the account that received the notification. When provided,
+   * the account's localpart is appended to the title so multi-account users know
+   * which account the notification is for. */
+  recipientId?: string;
 };
 
 type NotificationPayload = {
@@ -62,6 +66,9 @@ export const resolveNotificationPreviewText = ({
   return encryptedContext ? ENCRYPTED_MESSAGE_PREVIEW : DEFAULT_MESSAGE_PREVIEW;
 };
 
+/** Extracts the localpart (everything between @ and the first :) from a Matrix user ID. */
+const toLocalpart = (userId: string): string => userId.match(/^@([^:]+):/)?.[1] ?? userId;
+
 export const buildRoomMessageNotification = ({
   roomName,
   username,
@@ -70,14 +77,16 @@ export const buildRoomMessageNotification = ({
   silent,
   eventId,
   data,
+  recipientId,
 }: RoomMessageNotificationInput): NotificationPayload => {
   const sender = getString(username, 'Someone');
   const room = getString(roomName, 'Unknown');
   const message = getString(previewText, DEFAULT_MESSAGE_PREVIEW);
   const avatar = getString(roomAvatar, DEFAULT_NOTIFICATION_ICON);
+  const recipientSuffix = recipientId ? ` • ${toLocalpart(recipientId)}` : '';
 
   return {
-    title: `${sender} in ${room}`,
+    title: `${sender} in ${room}${recipientSuffix}`,
     options: {
       icon: avatar,
       badge: avatar || DEFAULT_NOTIFICATION_BADGE,

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -13,6 +13,7 @@ import {
   MatrixEvent,
   MsgType,
   NotificationCountType,
+  PushProcessor,
   RelationType,
   Room,
   RoomMember,
@@ -240,18 +241,24 @@ export const getUnreadInfo = (room: Room, options?: UnreadInfoOptions): UnreadIn
   }
 
   let total = room.getUnreadNotificationCount(NotificationCountType.Total);
-  let highlight = room.getUnreadNotificationCount(NotificationCountType.Highlight);
-  let syntheticDotUnread = false;
+  const highlight = room.getUnreadNotificationCount(NotificationCountType.Highlight);
 
   // If our latest main-timeline notification event is confirmed read, clamp its stale count.
   // Only apply to the room (non-thread) portion so thread reply counts are preserved.
-  if (userId && total > 0 && highlight === 0) {
+  // Guard: only clamp when the room has NO receipt-confirmed unread events; if roomHaveUnread
+  // is true then there genuinely are unread messages and the SDK count is not fully stale.
+  if (userId && total > 0 && highlight === 0 && !roomHaveUnread(room.client, room)) {
     const roomTotal = room.getRoomUnreadNotificationCount(NotificationCountType.Total);
     if (roomTotal > 0) {
       const liveEvents = room.getLiveTimeline().getEvents();
+      // Exclude the user's own messages: own sent events are always "read" (hasUserReadEvent
+      // returns true for them), which would cause the clamp to fire incorrectly.
       const latestNotification = [...liveEvents]
         .reverse()
-        .find((event) => !event.isSending() && isNotificationEvent(event));
+        .find(
+          (event) =>
+            !event.isSending() && event.getSender() !== userId && isNotificationEvent(event)
+        );
       const latestNotificationId = latestNotification?.getId();
       if (latestNotificationId && room.hasUserReadEvent(userId, latestNotificationId)) {
         // Subtract only the stale main-timeline count; thread totals remain intact.
@@ -260,19 +267,34 @@ export const getUnreadInfo = (room: Room, options?: UnreadInfoOptions): UnreadIn
     }
   }
 
-  // Fallback for cases where SDK counters are stale/zero but unread-by-receipt state still exists.
-  // Represent as a dot badge (count=0) rather than a numeric badge.
-  if (total === 0 && highlight === 0 && roomHaveUnread(room.client, room)) {
-    highlight = 1;
-    syntheticDotUnread = true;
+  // Fallback: SDK counters are stale/zero but there are receipt-confirmed unread
+  // messages. Walk the live timeline to compute real counts so the badge number
+  // and highlight colour reflect actual state rather than a hard-coded stub.
+  if (total === 0 && highlight === 0 && userId && roomHaveUnread(room.client, room)) {
+    const readUpToId = room.getEventReadUpTo(userId);
+    const liveEvents = room.getLiveTimeline().getEvents();
+    let fallbackTotal = 0;
+    let fallbackHighlight = 0;
+    const pushProcessor = new PushProcessor(room.client);
+    for (let i = liveEvents.length - 1; i >= 0; i -= 1) {
+      const event = liveEvents[i];
+      if (!event) break;
+      if (event.getId() === readUpToId) break;
+      if (isNotificationEvent(event) && event.getSender() !== userId) {
+        fallbackTotal += 1;
+        const pushActions = pushProcessor.actionsForEvent(event);
+        if (pushActions?.tweaks?.highlight) fallbackHighlight += 1;
+      }
+    }
+    if (fallbackTotal > 0) {
+      return { roomId: room.roomId, highlight: fallbackHighlight, total: fallbackTotal };
+    }
   }
-
-  const resolvedTotal = syntheticDotUnread ? total : Math.max(total, highlight);
 
   return {
     roomId: room.roomId,
     highlight,
-    total: resolvedTotal,
+    total: Math.max(total, highlight),
   };
 };
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -17,6 +17,47 @@ const { handlePushNotificationPushData } = createPushNotifications(self, () => (
   showEncryptedMessageContent,
 }));
 
+/** Cache key used to persist notification settings across SW restarts (iOS kills the SW frequently). */
+const SW_SETTINGS_CACHE = 'sable-sw-settings-v1';
+const SW_SETTINGS_URL = '/sw-settings-meta';
+
+async function persistSettings() {
+  try {
+    const cache = await self.caches.open(SW_SETTINGS_CACHE);
+    await cache.put(
+      SW_SETTINGS_URL,
+      new Response(
+        JSON.stringify({
+          notificationSoundEnabled,
+          preferPushOnMobile,
+          showMessageContent,
+          showEncryptedMessageContent,
+        }),
+        { headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+  } catch {
+    // Ignore — caches may be unavailable in some environments.
+  }
+}
+
+async function loadPersistedSettings() {
+  try {
+    const cache = await self.caches.open(SW_SETTINGS_CACHE);
+    const response = await cache.match(SW_SETTINGS_URL);
+    if (!response) return;
+    const s = await response.json();
+    if (typeof s.notificationSoundEnabled === 'boolean')
+      notificationSoundEnabled = s.notificationSoundEnabled;
+    if (typeof s.preferPushOnMobile === 'boolean') preferPushOnMobile = s.preferPushOnMobile;
+    if (typeof s.showMessageContent === 'boolean') showMessageContent = s.showMessageContent;
+    if (typeof s.showEncryptedMessageContent === 'boolean')
+      showEncryptedMessageContent = s.showEncryptedMessageContent;
+  } catch {
+    // Ignore — stale or missing cache is fine; we fall back to defaults.
+  }
+}
+
 type SessionInfo = {
   accessToken: string;
   baseUrl: string;
@@ -138,6 +179,8 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
       showEncryptedMessageContent = (data as { showEncryptedMessageContent: boolean })
         .showEncryptedMessageContent;
     }
+    // Persist so settings survive SW restart (iOS kills the SW aggressively).
+    event.waitUntil(persistSettings());
   }
 });
 
@@ -213,6 +256,10 @@ const onPushNotification = async (event: PushEvent) => {
     return;
   }
 
+  // The SW may have been restarted by the OS (iOS is aggressive about this),
+  // so in-memory settings would be at their defaults. Reload from the cache.
+  await loadPersistedSettings();
+
   const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
   const hasVisibleClient = clients.some((client) => client.visibilityState === 'visible');
   if (hasVisibleClient && !preferPushOnMobile) {
@@ -258,8 +305,16 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
     (eventType === EventType.RoomMessage || eventType === EventType.RoomMessageEncrypted) &&
     messageData?.room_id &&
     messageData?.event_id
-  )
-    targetUrl = `${scope}to/${messageData.room_id}/${messageData.event_id}`;
+  ) {
+    // Include the target user ID as ?uid= so ToRoomEvent can switch to the
+    // correct account before navigating. This covers client.navigate() on iOS
+    // Safari where postMessage is unreliable after focus().
+    const uidParam =
+      typeof messageData?.user_id === 'string'
+        ? `?uid=${encodeURIComponent(messageData.user_id)}`
+        : '';
+    targetUrl = `${scope}to/${messageData.room_id}/${messageData.event_id}${uidParam}`;
+  }
   if (eventType === EventType.RoomMember && messageData?.content?.membership === 'invite')
     targetUrl = `${scope}inbox/invites/`;
 
@@ -272,13 +327,27 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
-      const focusedClient = clientList.find((client): client is WindowClient => 'focus' in client);
+      // Prefer a visible (foreground) tab; fall back to any open window client.
+      const focusedClient =
+        clientList.find((c) => c.visibilityState === 'visible') ??
+        clientList.find((c): c is WindowClient => 'focus' in c);
       if (focusedClient) {
-        return focusedClient.focus().then(() => {
-          postMessageToClient(focusedClient);
+        return focusedClient.focus().then((wc) => {
+          // Prefer client.navigate() — draft API, available on Chrome/Chromium
+          // (all Android PWAs and desktop), unavailable on iOS Safari / Firefox.
+          const client = wc ?? focusedClient;
+          if ('navigate' in client && typeof (client as any).navigate === 'function') {
+            return (client as any).navigate(targetUrl);
+          }
+          // navigate() unavailable: use postMessage. The existing client (whether
+          // it was in the foreground or just minimized) has a live JS context by
+          // the time focus() resolves. HandleNotificationClick in the page will
+          // receive the message and dispatch the account-switch + deep link.
+          postMessageToClient(client);
           return null;
         });
       }
+      // No existing client — open a new window. ToRoomEvent handles the route.
       if (self.clients.openWindow) {
         return self.clients.openWindow(targetUrl).then(() => null);
       }

--- a/src/sw/pushNotification.ts
+++ b/src/sw/pushNotification.ts
@@ -16,8 +16,11 @@ export const createPushNotifications = (
   self: ServiceWorkerGlobalScope,
   getNotificationSettings: () => NotificationSettings
 ) => {
-  const resolveSilent = (silent: unknown): boolean => {
+  const resolveSilent = (silent: unknown, tweakSound?: unknown): boolean => {
     if (typeof silent === 'boolean') return silent;
+    // If the push rule doesn't request a sound tweak, the notification should be silent
+    // (no sound), regardless of the user's global sound preference.
+    if (!tweakSound) return true;
     return !getNotificationSettings().notificationSoundEnabled;
   };
 
@@ -29,14 +32,24 @@ export const createPushNotifications = (
     icon?: string,
     badge?: string
   ) => {
-    await self.registration.showNotification(title, {
+    const roomId: string | undefined = data?.room_id;
+    // Group by room so new messages in the same room replace the previous
+    // notification rather than stacking individually. renotify: true ensures
+    // the user is still alerted when the existing tag is replaced.
+    const tag = roomId ? `room-${roomId}` : (data?.event_id ?? 'Cinny');
+    const renotify = !!roomId;
+    // `renotify` is a valid Web API property absent from TypeScript's NotificationOptions type.
+    // Build the options object separately to avoid the excess-property check, then cast.
+    const notifOptions = {
       body,
       icon: icon ?? DEFAULT_NOTIFICATION_ICON,
       badge: badge ?? DEFAULT_NOTIFICATION_BADGE,
-      tag: data?.event_id ?? 'Cinny',
+      tag,
+      renotify,
       silent,
       data,
-    });
+    };
+    await self.registration.showNotification(title, notifOptions as NotificationOptions);
   };
 
   const handleRoomMessageNotification = async (pushData: any) => {
@@ -59,8 +72,9 @@ export const createPushNotifications = (
         showMessageContent: getNotificationSettings().showMessageContent,
         showEncryptedMessageContent: getNotificationSettings().showEncryptedMessageContent,
       }),
-      silent: resolveSilent(pushData?.silent),
+      silent: resolveSilent(pushData?.silent, pushData?.tweaks?.sound),
       eventId: pushData?.event_id,
+      recipientId: typeof pushData?.user_id === 'string' ? pushData.user_id : undefined,
       data,
     });
     await showNotificationWithData(
@@ -93,8 +107,9 @@ export const createPushNotifications = (
         showMessageContent: getNotificationSettings().showMessageContent,
         showEncryptedMessageContent: getNotificationSettings().showEncryptedMessageContent,
       }),
-      silent: resolveSilent(pushData?.silent),
+      silent: resolveSilent(pushData?.silent, pushData?.tweaks?.sound),
       eventId: pushData?.event_id,
+      recipientId: typeof pushData?.user_id === 'string' ? pushData.user_id : undefined,
       data,
     });
     await showNotificationWithData(
@@ -128,27 +143,6 @@ export const createPushNotifications = (
     await showNotificationWithData('New Invitation', body, data, resolveSilent(pushData?.silent));
   };
 
-  const fallbackNotification = async (pushData: any) => {
-    const body = pushData?.content?.body;
-    let title;
-    if (body) {
-      title = pushData?.sender_display_name
-        ? `${pushData.sender_display_name}${pushData?.room_name ? ` in ${pushData.room_name}` : ''}`
-        : 'New Notification';
-    } else {
-      title = 'You have a new Notification';
-    }
-    const data = {
-      type: pushData?.type,
-      room_id: pushData?.room_id,
-      event_id: pushData?.event_id,
-      user_id: pushData?.user_id,
-      timestamp: Date.now(),
-      ...pushData.data,
-    };
-    await showNotificationWithData(title, body, data, resolveSilent(pushData?.silent));
-  };
-
   const handlePushNotificationPushData = async (pushData: any) => {
     const eventType = pushData?.type as EventType | undefined;
     if (!eventType) {
@@ -158,19 +152,19 @@ export const createPushNotifications = (
     switch (eventType) {
       case EventType.RoomMessage:
       case EventType.Sticker:
-        return handleRoomMessageNotification(pushData);
+        await handleRoomMessageNotification(pushData);
+        break;
       case EventType.RoomMessageEncrypted:
-        return handleEncryptedMessageNotification(pushData);
+        await handleEncryptedMessageNotification(pushData);
+        break;
       case EventType.RoomMember:
         if (!(pushData?.content?.membership === 'invite')) break;
-        return handleInvitationNotification(pushData);
-
+        await handleInvitationNotification(pushData);
+        break;
       default:
         // no voip support in app anyway
         break;
     }
-
-    return fallbackNotification(pushData);
   };
 
   return { handlePushNotificationPushData };


### PR DESCRIPTION
Fixes several notification issues, primarily on iOS, and adds a new appearance setting.

**Notification fixes**
- Deep link events no longer repeatedly pull the user back on every incoming message
- Tapping a notification for a backgrounded account now correctly switches accounts and deep links to the event
- iOS Safari's `event.source = null` behaviour no longer silently drops SW postMessages
  - Note that on iOS, it is not possible to get notifications for backgrounded accounts, and clicking on a notification surfacing from a backgrounded account does not currently work.
- Notification click routing uses `postMessage` for open clients and `openWindow` only when the app is closed

**New setting**
- Appearance → Visual Tweaks: "Show Unread Counts" toggle — hides numeric counts on room/sidebar badges while keeping the dot indicator (default on)