### PR TITLE
fix: message send UX improvements

### DIFF
--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -499,12 +499,10 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           // Cancel failed — leave state intact for retry
         }
       } else {
-        try {
-          await mx.sendMessage(roomId, content as any);
-        } catch (error) {
-          log.error('failed to send message', { roomId }, error);
-        }
         resetInput();
+        mx.sendMessage(roomId, content as any).catch((error: unknown) => {
+          log.error('failed to send message', { roomId }, error);
+        });
       }
     }, [
       mx,

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1197,6 +1197,14 @@ export function RoomTimeline({
     [mx, room]
   );
 
+  const handleDeleteFailedSend = useCallback(
+    (mEvent: MatrixEvent) => {
+      if (mEvent.getAssociatedStatus() !== EventStatus.NOT_SENT) return;
+      mx.cancelPendingEvent(mEvent);
+    },
+    [mx]
+  );
+
   const handleEdit = useCallback(
     (editEvtId?: string) => {
       if (editEvtId) {
@@ -1269,6 +1277,7 @@ export function RoomTimeline({
             senderDisplayName={senderDisplayName}
             sendStatus={mEvent.getAssociatedStatus()}
             onResend={handleResend}
+            onDeleteFailedSend={handleDeleteFailedSend}
             onEditId={handleEdit}
             activeReplyId={activeReplyId}
             reply={
@@ -1356,6 +1365,7 @@ export function RoomTimeline({
             senderDisplayName={senderDisplayName}
             sendStatus={mEvent.getAssociatedStatus()}
             onResend={handleResend}
+            onDeleteFailedSend={handleDeleteFailedSend}
             reply={
               replyEventId && (
                 <Reply
@@ -1474,6 +1484,7 @@ export function RoomTimeline({
             senderDisplayName={senderDisplayName}
             sendStatus={mEvent.getAssociatedStatus()}
             onResend={handleResend}
+            onDeleteFailedSend={handleDeleteFailedSend}
             reply={
               replyEventId && (
                 <Reply

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -227,6 +227,7 @@ export type MessageProps = {
   activeReplyId?: string | null;
   sendStatus?: EventStatus | null;
   onResend?: (event: MatrixEvent) => void;
+  onDeleteFailedSend?: (event: MatrixEvent) => void;
 };
 
 function useMobileDoubleTap(callback: () => void, delay = 300) {
@@ -308,6 +309,7 @@ function MessageInternal(
     activeReplyId,
     sendStatus,
     onResend,
+    onDeleteFailedSend,
     ...props
   }: MessageProps & { className?: string; children?: ReactNode },
   ref: any
@@ -445,6 +447,7 @@ function MessageInternal(
     sendStatus === EventStatus.SENDING;
   const isFailedSend = sendStatus === EventStatus.NOT_SENT;
   const canResend = isFailedSend && senderId === mx.getUserId() && !!onResend;
+  const canDeleteFailedSend = isFailedSend && senderId === mx.getUserId() && !!onDeleteFailedSend;
 
   const handleResendClick: MouseEventHandler<HTMLButtonElement> = useCallback(
     (evt) => {
@@ -453,6 +456,15 @@ function MessageInternal(
       onResend?.(mEvent);
     },
     [mEvent, onResend]
+  );
+
+  const handleDeleteFailedSendClick: MouseEventHandler<HTMLButtonElement> = useCallback(
+    (evt) => {
+      evt.preventDefault();
+      evt.stopPropagation();
+      onDeleteFailedSend?.(mEvent);
+    },
+    [mEvent, onDeleteFailedSend]
   );
 
   const MSG_CONTENT_STYLE = { maxWidth: '100%' };
@@ -484,13 +496,6 @@ function MessageInternal(
         <MemoizedBody key={stableContent}>{children}</MemoizedBody>
       )}
       {reactions}
-      {isPendingSend && (
-        <Box className={css.SendStatusRow}>
-          <Text size="T200" priority="300">
-            Sending...
-          </Text>
-        </Box>
-      )}
       {isFailedSend && (
         <Box className={css.SendStatusRow}>
           <Text size="T200" priority="300">
@@ -499,6 +504,11 @@ function MessageInternal(
           {canResend && (
             <button type="button" className={css.SendStatusButton} onClick={handleResendClick}>
               Retry
+            </button>
+          )}
+          {canDeleteFailedSend && (
+            <button type="button" className={css.SendStatusButton} onClick={handleDeleteFailedSendClick}>
+              Delete
             </button>
           )}
         </Box>

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -507,7 +507,11 @@ function MessageInternal(
             </button>
           )}
           {canDeleteFailedSend && (
-            <button type="button" className={css.SendStatusButton} onClick={handleDeleteFailedSendClick}>
+            <button
+              type="button"
+              className={css.SendStatusButton}
+              onClick={handleDeleteFailedSendClick}
+            >
               Delete
             </button>
           )}

--- a/src/app/features/room/message/styles.css.ts
+++ b/src/app/features/room/message/styles.css.ts
@@ -57,11 +57,11 @@ export const ReactionsTooltipText = style({
 });
 
 export const MessagePending = style({
-  opacity: config.opacity.P500,
+  opacity: config.opacity.Placeholder,
 });
 
 export const MessageFailed = style({
-  opacity: config.opacity.P400,
+  opacity: config.opacity.P300,
 });
 
 export const SendStatusRow = style({


### PR DESCRIPTION
Changes:
- Removes "sending..." text (to prevent timeline jump)
- Properly dims messages that are pending send
- Adds a retry/delete button on the message if it fails