### PR TITLE
feat: quick react via message editor 

### DIFF
--- a/src/app/components/editor/autocomplete/EmoticonAutocomplete.tsx
+++ b/src/app/components/editor/autocomplete/EmoticonAutocomplete.tsx
@@ -23,10 +23,14 @@ type EmoticonCompleteHandler = (key: string, shortcode: string) => void;
 type EmoticonSearchItem = PackImageReader | IEmoji;
 
 type EmoticonAutocompleteProps = {
+  title?: string;
   imagePackRooms: Room[];
   editor: Editor;
   query: AutocompleteQuery<string>;
   requestClose: () => void;
+  // this allows you to override the default behaviour of inserting the selection
+  // used to implement the +: reaction shortcut
+  onEmoticonSelected?: EmoticonCompleteHandler;
 };
 
 const SEARCH_OPTIONS: UseAsyncSearchOptions = {
@@ -36,10 +40,12 @@ const SEARCH_OPTIONS: UseAsyncSearchOptions = {
 };
 
 export function EmoticonAutocomplete({
+  title,
   imagePackRooms,
   editor,
   query,
   requestClose,
+  onEmoticonSelected,
 }: EmoticonAutocompleteProps) {
   const mx = useMatrixClient();
   const useAuthentication = useMediaAuthentication();
@@ -67,12 +73,14 @@ export function EmoticonAutocomplete({
     else resetSearch();
   }, [query.text, search, resetSearch]);
 
-  const handleAutocomplete: EmoticonCompleteHandler = (key, shortcode) => {
-    const emoticonEl = createEmoticonElement(key, shortcode);
-    replaceWithElement(editor, query.range, emoticonEl);
-    moveCursor(editor, true);
-    requestClose();
-  };
+  const handleAutocomplete: EmoticonCompleteHandler =
+    onEmoticonSelected ??
+    ((key, shortcode) => {
+      const emoticonEl = createEmoticonElement(key, shortcode);
+      replaceWithElement(editor, query.range, emoticonEl);
+      moveCursor(editor, true);
+      requestClose();
+    });
 
   useKeyDown(window, (evt: KeyboardEvent) => {
     onTabPress(evt, () => {
@@ -84,7 +92,10 @@ export function EmoticonAutocomplete({
   });
 
   return autoCompleteEmoticon.length === 0 ? null : (
-    <AutocompleteMenu headerContent={<Text size="L400">Emojis</Text>} requestClose={requestClose}>
+    <AutocompleteMenu
+      headerContent={<Text size="L400">{title ?? 'Emojis'}</Text>}
+      requestClose={requestClose}
+    >
       {autoCompleteEmoticon.map((emoticon) => {
         const isCustomEmoji = 'url' in emoticon;
         const key = isCustomEmoji ? emoticon.url : emoticon.unicode;

--- a/src/app/components/editor/autocomplete/autocompleteQuery.ts
+++ b/src/app/components/editor/autocomplete/autocompleteQuery.ts
@@ -5,12 +5,16 @@ export enum AutocompletePrefix {
   UserMention = '@',
   Emoticon = ':',
   Command = '/',
+  Reaction = '+:',
 }
-export const AUTOCOMPLETE_PREFIXES: readonly AutocompletePrefix[] = [
+export const ANYWHERE_AUTOCOMPLETE_PREFIXES: readonly AutocompletePrefix[] = [
   AutocompletePrefix.RoomMention,
   AutocompletePrefix.UserMention,
   AutocompletePrefix.Emoticon,
+];
+export const BEGINNING_AUTOCOMPLETE_PREFIXES: readonly AutocompletePrefix[] = [
   AutocompletePrefix.Command,
+  AutocompletePrefix.Reaction,
 ];
 
 export type AutocompleteQuery<TPrefix extends string> = {
@@ -34,7 +38,7 @@ export const getAutocompleteQueryText = (
   prefix: string
 ): string => Editor.string(editor, queryRange).slice(prefix.length);
 
-export const getAutocompleteQuery = <TPrefix extends string>(
+export const getAutocompleteQuery = <TPrefix extends string = AutocompletePrefix>(
   editor: Editor,
   queryRange: BaseRange,
   validPrefixes: readonly TPrefix[]

--- a/src/app/components/editor/utils.ts
+++ b/src/app/components/editor/utils.ts
@@ -261,7 +261,8 @@ export const getPrevWorldRange = (editor: Editor): BaseRange | undefined => {
   const [cursorPoint] = Range.edges(selection);
   const worldStartPoint = getPointUntilChar(editor, cursorPoint, {
     reverse: true,
-    match: (char) => char === ' ',
+    // line breaks produce empty chars, not \n
+    match: (char) => /\s|^$/.test(char),
   });
   return worldStartPoint && Editor.range(editor, worldStartPoint, cursorPoint);
 };

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -21,7 +21,7 @@ import {
   StickerEventContent,
 } from '$types/matrix-sdk';
 import { ReactEditor } from 'slate-react';
-import { Editor, Transforms } from 'slate';
+import { Editor, Point, Range, Transforms } from 'slate';
 import {
   Box,
   config,
@@ -51,7 +51,6 @@ import {
 
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import {
-  AUTOCOMPLETE_PREFIXES,
   AutocompletePrefix,
   AutocompleteQuery,
   createEmoticonElement,
@@ -73,6 +72,8 @@ import {
   getBeginCommand,
   trimCommand,
   getMentions,
+  ANYWHERE_AUTOCOMPLETE_PREFIXES,
+  BEGINNING_AUTOCOMPLETE_PREFIXES,
 } from '$components/editor';
 import { EmojiBoard, EmojiBoardTab } from '$components/emoji-board';
 import { UseStateProvider } from '$components/UseStateProvider';
@@ -82,6 +83,7 @@ import {
   getImageInfo,
   getMxIdLocalPart,
   mxcUrlToHttp,
+  toggleReaction,
 } from '$utils/matrix';
 import { useTypingStatusUpdater } from '$hooks/useTypingStatusUpdater';
 import { useFilePicker } from '$hooks/useFilePicker';
@@ -141,6 +143,7 @@ import {
 } from '$utils/delayedEvents';
 import { timeHourMinute, timeDayMonthYear } from '$utils/time';
 import { stopPropagation } from '$utils/keyboard';
+import { MessageEvent } from '$types/matrix/room';
 import { SchedulePickerDialog } from './schedule-send';
 import * as css from './schedule-send/SchedulePickerDialog.css';
 import {
@@ -559,9 +562,19 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         }
 
         const prevWordRange = getPrevWorldRange(editor);
-        const query = prevWordRange
-          ? getAutocompleteQuery<AutocompletePrefix>(editor, prevWordRange, AUTOCOMPLETE_PREFIXES)
-          : undefined;
+        if (!prevWordRange) {
+          setAutocompleteQuery(undefined);
+          return;
+        }
+
+        const firstPosition = Editor.start(editor, []);
+        const isRangeAtBeginning = !Point.isAfter(Range.start(prevWordRange), firstPosition);
+        const query =
+          (isRangeAtBeginning
+            ? getAutocompleteQuery(editor, prevWordRange, BEGINNING_AUTOCOMPLETE_PREFIXES)
+            : undefined) ??
+          getAutocompleteQuery(editor, prevWordRange, ANYWHERE_AUTOCOMPLETE_PREFIXES);
+
         setAutocompleteQuery(query);
       },
       [editor, sendTypingStatus, hideActivity]
@@ -571,6 +584,31 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       setAutocompleteQuery(undefined);
       ReactEditor.focus(editor);
     }, [editor]);
+
+    const handleReactionAutocomplete = (key: string, shortcode: string) => {
+      const lastMessage = room
+        .getLiveTimeline()
+        .getEvents()
+        .findLast((event) =>
+          (
+            [
+              MessageEvent.RoomMessage,
+              MessageEvent.RoomMessageEncrypted,
+              MessageEvent.Sticker,
+            ] as string[]
+          ).includes(event.getType())
+        );
+      const lastMessageId = lastMessage?.getId();
+
+      if (lastMessageId) {
+        toggleReaction(mx, room, lastMessageId, key, shortcode);
+      }
+
+      resetEditor(editor);
+      resetEditorHistory(editor);
+      sendTypingStatus(false);
+      handleCloseAutocomplete();
+    };
 
     const handleEmoticonSelect = (key: string, shortcode: string) => {
       editor.insertNode(createEmoticonElement(key, shortcode));
@@ -678,6 +716,16 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
             editor={editor}
             query={autocompleteQuery}
             requestClose={handleCloseAutocomplete}
+          />
+        )}
+        {autocompleteQuery?.prefix === AutocompletePrefix.Reaction && (
+          <EmoticonAutocomplete
+            title={`React with :${autocompleteQuery.text}`}
+            imagePackRooms={imagePackRooms}
+            editor={editor}
+            query={autocompleteQuery}
+            requestClose={handleCloseAutocomplete}
+            onEmoticonSelected={handleReactionAutocomplete}
           />
         )}
         {autocompleteQuery?.prefix === AutocompletePrefix.Command && (

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -51,7 +51,7 @@ import {
 import { isKeyHotkey } from 'is-hotkey';
 import { Opts as LinkifyOpts } from 'linkifyjs';
 import { useTranslation } from 'react-i18next';
-import { eventWithShortcode, factoryEventSentBy, getMxIdLocalPart } from '$utils/matrix';
+import { getMxIdLocalPart, toggleReaction } from '$utils/matrix';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { ItemRange, useVirtualPaginator } from '$hooks/useVirtualPaginator';
 import { useAlive } from '$hooks/useAlive';
@@ -85,7 +85,6 @@ import {
   getEventReactions,
   getLatestEditableEvt,
   getMemberDisplayName,
-  getReactionContent,
   isMembershipChanged,
   reactionOrEditEvent,
 } from '$utils/room';
@@ -1166,26 +1165,8 @@ export function RoomTimeline({
   );
 
   const handleReactionToggle = useCallback(
-    (targetEventId: string, key: string, shortcode?: string) => {
-      const relations = getEventReactions(room.getUnfilteredTimelineSet(), targetEventId);
-      const allReactions = relations?.getSortedAnnotationsByKey() ?? [];
-      const [, reactionsSet] = allReactions.find(([k]: [string, any]) => k === key) ?? [];
-      const reactions: MatrixEvent[] = reactionsSet ? Array.from(reactionsSet) : [];
-      const myReaction = reactions.find(factoryEventSentBy(mx.getUserId()!));
-
-      if (myReaction && !!(myReaction as any)?.isRelation()) {
-        mx.redactEvent(room.roomId, (myReaction as any).getId());
-        return;
-      }
-      const rShortcode =
-        shortcode ||
-        ((reactions.find(eventWithShortcode) as any)?.getContent().shortcode as string | undefined);
-      mx.sendEvent(
-        room.roomId,
-        MessageEvent.Reaction as any,
-        getReactionContent(targetEventId, key, rShortcode)
-      );
-    },
+    (targetEventId: string, key: string, shortcode?: string) =>
+      toggleReaction(mx, room, targetEventId, key, shortcode),
     [mx, room]
   );
 

--- a/src/app/features/room/message/MessageEditor.tsx
+++ b/src/app/features/room/message/MessageEditor.tsx
@@ -27,7 +27,6 @@ import {
 } from '$types/matrix-sdk';
 import { isKeyHotkey } from 'is-hotkey';
 import {
-  AUTOCOMPLETE_PREFIXES,
   AutocompletePrefix,
   AutocompleteQuery,
   CustomEditor,
@@ -47,6 +46,7 @@ import {
   trimCustomHtml,
   useEditor,
   getMentions,
+  ANYWHERE_AUTOCOMPLETE_PREFIXES,
 } from '$components/editor';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
@@ -207,7 +207,7 @@ export const MessageEditor = as<'div', MessageEditorProps>(
 
         const prevWordRange = getPrevWorldRange(editor);
         const query = prevWordRange
-          ? getAutocompleteQuery<AutocompletePrefix>(editor, prevWordRange, AUTOCOMPLETE_PREFIXES)
+          ? getAutocompleteQuery(editor, prevWordRange, ANYWHERE_AUTOCOMPLETE_PREFIXES)
           : undefined;
         setAutocompleteQuery(query);
       },

--- a/src/app/features/settings/account/BioEditor.tsx
+++ b/src/app/features/settings/account/BioEditor.tsx
@@ -16,7 +16,6 @@ import { Editor, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { isKeyHotkey } from 'is-hotkey';
 import {
-  AUTOCOMPLETE_PREFIXES,
   AutocompletePrefix,
   AutocompleteQuery,
   CustomEditor,
@@ -145,7 +144,7 @@ export function BioEditor({ value, isSaving, imagePackRooms, onSave }: BioEditor
       }
       const prevWordRange = getPrevWorldRange(editor);
       const query = prevWordRange
-        ? getAutocompleteQuery<AutocompletePrefix>(editor, prevWordRange, AUTOCOMPLETE_PREFIXES)
+        ? getAutocompleteQuery(editor, prevWordRange, [AutocompletePrefix.Emoticon])
         : undefined;
       setAutocompleteQuery(query);
     },

--- a/src/app/utils/matrix.ts
+++ b/src/app/utils/matrix.ts
@@ -16,8 +16,8 @@ import {
 import to from 'await-to-js';
 import { IImageInfo, IThumbnailContent, IVideoInfo } from '$types/matrix/common';
 import { AccountDataEvent } from '$types/matrix/accountData';
-import { Membership, StateEvent } from '$types/matrix/room';
-import { getStateEvent } from './room';
+import { Membership, MessageEvent, StateEvent } from '$types/matrix/room';
+import { getEventReactions, getReactionContent, getStateEvent } from './room';
 
 const DOMAIN_REGEX = /\b(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}\b/;
 
@@ -381,4 +381,30 @@ export const knockRestrictedSupported = (version: string): boolean => {
 export const creatorsSupported = (version: string): boolean => {
   const unsupportedVersion = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'];
   return !unsupportedVersion.includes(version);
+};
+
+export const toggleReaction = (
+  mx: MatrixClient,
+  room: Room,
+  targetEventId: string,
+  key: string,
+  shortcode?: string
+) => {
+  const relations = getEventReactions(room.getUnfilteredTimelineSet(), targetEventId);
+  const allReactions = relations?.getSortedAnnotationsByKey() ?? [];
+  const [, reactionsSet] = allReactions.find(([k]: [string, any]) => k === key) ?? [];
+  const reactions: MatrixEvent[] = reactionsSet ? Array.from(reactionsSet) : [];
+  const myReaction = reactions.find(factoryEventSentBy(mx.getUserId()!));
+
+  if (myReaction && !!(myReaction as any)?.isRelation()) {
+    mx.redactEvent(room.roomId, (myReaction as any).getId());
+    return;
+  }
+  const rShortcode =
+    shortcode || (reactions.find(eventWithShortcode)?.getContent().shortcode as string | undefined);
+  mx.sendEvent(
+    room.roomId,
+    MessageEvent.Reaction as any,
+    getReactionContent(targetEventId, key, rShortcode)
+  );
 };


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

typing `+:` in the message editor will bring up the emoticon autocomplete prompt, where choosing an emoticon will clear the editor and react with that emoticon under the latest message

[reactions.webm](https://github.com/user-attachments/assets/d4807fd5-348f-45ff-8507-defd92d7a865)

this pr also splits the autocomplete prefixes in two: ones that can be used anywhere in the message, and those that only work at the beginning

also i set a default type param on one of the autocomplete query functions because who wants to keep typing out that type everywhere all the time

also there was some minor code deduplication and a fix to the autocomplete query system

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
  - as much as i can do myself - i'm very much new to writing matrix clients, i might've done something terribly stupid
- [x] I have commented my code, particularly in hard-to-understand areas
  - do self-descriptive variable names and one new comment count?
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
