### PR TITLE
fix(sliding-sync): cache emoji packs, fix edit message rendering

### DIFF
--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -23,6 +23,7 @@ import {
   IRoomTimelineData,
   MatrixClient,
   MatrixEvent,
+  RelationType,
   Room,
   RoomEvent,
   RoomEventHandlerMap,
@@ -451,6 +452,30 @@ const useLiveEventArrive = (room: Room, onArrive: (mEvent: MatrixEvent) => void)
   }, [room, onArrive]);
 };
 
+const useRelationUpdate = (room: Room, onRelation: () => void) => {
+  useEffect(() => {
+    const handleTimelineEvent: EventTimelineSetHandlerMap[RoomEvent.Timeline] = (
+      mEvent: MatrixEvent,
+      eventRoom: Room | undefined,
+      _toStartOfTimeline: boolean | undefined,
+      _removed: boolean,
+      data: IRoomTimelineData
+    ) => {
+      // Live Replace events are handled by useLiveEventArrive re-render.
+      // Non-live Replace events (bundled/historical edits from sliding sync)
+      // also need to trigger a re-render so makeReplaced state is reflected.
+      if (eventRoom?.roomId !== room.roomId || data.liveEvent) return;
+      if (mEvent.getRelation()?.rel_type === RelationType.Replace) {
+        onRelation();
+      }
+    };
+    room.on(RoomEvent.Timeline, handleTimelineEvent);
+    return () => {
+      room.removeListener(RoomEvent.Timeline, handleTimelineEvent);
+    };
+  }, [room, onRelation]);
+};
+
 const useLiveTimelineRefresh = (room: Room, onRefresh: () => void) => {
   useEffect(() => {
     const handleTimelineRefresh: RoomEventHandlerMap[RoomEvent.TimelineRefresh] = (r: Room) => {
@@ -784,6 +809,15 @@ export function RoomTimeline({
         setTimeline(getInitialTimeline(room));
       }
     }, [room, liveTimelineLinked, timeline.linkedTimelines.length])
+  );
+
+  // Re-render when non-live Replace relations arrive (bundled/historical edits
+  // from sliding sync that wouldn't otherwise trigger a timeline update).
+  useRelationUpdate(
+    room,
+    useCallback(() => {
+      setTimeline((ct) => ({ ...ct }));
+    }, [])
   );
 
   // Recover from transient empty timeline state when the live timeline
@@ -1226,8 +1260,14 @@ export function RoomTimeline({
         const highlighted = focusItem?.index === item && focusItem.highlight;
 
         const editedEvent = getEditedEvent(mEventId, mEvent, timelineSet);
-        const getContent = (() =>
-          editedEvent?.getContent()['m.new_content'] ?? mEvent.getContent()) as GetContentCallback;
+        const editedNewContent = editedEvent?.getContent()['m.new_content'];
+        // If makeReplaced was called with a stripped edit (no m.new_content),
+        // mEvent.getContent() returns {}. Fall back to getOriginalContent() so
+        // the message renders with its original content instead of breaking.
+        const baseContent = mEvent.getContent();
+        const safeContent =
+          Object.keys(baseContent).length > 0 ? baseContent : mEvent.getOriginalContent();
+        const getContent = (() => editedNewContent ?? safeContent) as GetContentCallback;
 
         const senderId = mEvent.getSender() ?? '';
         const senderDisplayName =
@@ -1295,7 +1335,7 @@ export function RoomTimeline({
             ) : (
               <RenderMessageContent
                 displayName={senderDisplayName}
-                msgType={mEvent.getContent().msgtype ?? ''}
+                msgType={(editedNewContent ?? safeContent).msgtype ?? ''}
                 ts={mEvent.getTs()}
                 edited={!!editedEvent}
                 getContent={getContent}
@@ -1395,14 +1435,16 @@ export function RoomTimeline({
                   );
                 if (mEvent.getType() === MessageEvent.RoomMessage) {
                   const editedEvent = getEditedEvent(mEventId, mEvent, timelineSet);
-                  const getContent = (() =>
-                    editedEvent?.getContent()['m.new_content'] ??
-                    mEvent.getContent()) as GetContentCallback;
+                  const editedNewContent = editedEvent?.getContent()['m.new_content'];
+                  const baseContent = mEvent.getContent();
+                  const safeContent =
+                    Object.keys(baseContent).length > 0 ? baseContent : mEvent.getOriginalContent();
+                  const getContent = (() => editedNewContent ?? safeContent) as GetContentCallback;
 
                   return (
                     <RenderMessageContent
                       displayName={senderDisplayName}
-                      msgType={mEvent.getContent().msgtype ?? ''}
+                      msgType={(editedNewContent ?? safeContent).msgtype ?? ''}
                       ts={mEvent.getTs()}
                       edited={!!editedEvent}
                       getContent={getContent}

--- a/src/app/hooks/useImagePacks.ts
+++ b/src/app/hooks/useImagePacks.ts
@@ -1,5 +1,5 @@
 import { Room } from '$types/matrix-sdk';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AccountDataEvent } from '$types/matrix/accountData';
 import { StateEvent } from '$types/matrix/room';
 import {
@@ -7,8 +7,15 @@ import {
   getRoomImagePack,
   getRoomImagePacks,
   getUserImagePack,
+  globalPacksScope,
   ImagePack,
   ImageUsage,
+  readCachedPack,
+  readCachedPacks,
+  roomPacksScope,
+  userPackScope,
+  writeCachedPack,
+  writeCachedPacks,
 } from '$plugins/custom-emoji';
 import { useMatrixClient } from './useMatrixClient';
 import { useAccountDataCallback } from './useAccountDataCallback';
@@ -48,7 +55,17 @@ const imagePackListEqual = (a: ImagePack[], b: ImagePack[]): boolean => {
 
 export const useUserImagePack = (): ImagePack | undefined => {
   const mx = useMatrixClient();
-  const [userPack, setUserPack] = useState(() => getUserImagePack(mx));
+  const [userPack, setUserPack] = useState<ImagePack | undefined>(() => {
+    const live = getUserImagePack(mx);
+    if (live) return live;
+    const userId = mx.getUserId();
+    return userId ? readCachedPack(userId, userPackScope()) : undefined;
+  });
+
+  useEffect(() => {
+    const userId = mx.getUserId();
+    if (userId) writeCachedPack(userId, userPackScope(), userPack);
+  }, [mx, userPack]);
 
   useAccountDataCallback(
     mx,
@@ -70,7 +87,17 @@ export const useUserImagePack = (): ImagePack | undefined => {
 
 export const useGlobalImagePacks = (): ImagePack[] => {
   const mx = useMatrixClient();
-  const [globalPacks, setGlobalPacks] = useState(() => getGlobalImagePacks(mx));
+  const [globalPacks, setGlobalPacks] = useState<ImagePack[]>(() => {
+    const live = getGlobalImagePacks(mx);
+    if (live.length > 0) return live;
+    const userId = mx.getUserId();
+    return userId ? readCachedPacks(userId, globalPacksScope()) : [];
+  });
+
+  useEffect(() => {
+    const userId = mx.getUserId();
+    if (userId) writeCachedPacks(userId, globalPacksScope(), globalPacks);
+  }, [mx, globalPacks]);
 
   useAccountDataCallback(
     mx,
@@ -115,7 +142,24 @@ export const useGlobalImagePacks = (): ImagePack[] => {
 
 export const useRoomImagePack = (room: Room, stateKey: string): ImagePack | undefined => {
   const mx = useMatrixClient();
-  const [roomPack, setRoomPack] = useState(() => getRoomImagePack(room, stateKey));
+  const [roomPack, setRoomPack] = useState<ImagePack | undefined>(() => {
+    const live = getRoomImagePack(room, stateKey);
+    if (live) return live;
+    const userId = mx.getUserId();
+    if (!userId) return undefined;
+    // Find a matching cached pack by roomId + stateKey
+    return readCachedPacks(userId, roomPacksScope(room.roomId)).find(
+      (p) => p.address?.stateKey === stateKey
+    );
+  });
+
+  useEffect(() => {
+    const userId = mx.getUserId();
+    if (!userId) return;
+    // Persist all packs for this room whenever this single-pack state changes
+    const scope = roomPacksScope(room.roomId);
+    writeCachedPack(userId, scope, roomPack);
+  }, [mx, room.roomId, roomPack]);
 
   useStateEventCallback(
     mx,
@@ -141,7 +185,17 @@ export const useRoomImagePack = (room: Room, stateKey: string): ImagePack | unde
 
 export const useRoomImagePacks = (room: Room): ImagePack[] => {
   const mx = useMatrixClient();
-  const [roomPacks, setRoomPacks] = useState(() => getRoomImagePacks(room));
+  const [roomPacks, setRoomPacks] = useState<ImagePack[]>(() => {
+    const live = getRoomImagePacks(room);
+    if (live.length > 0) return live;
+    const userId = mx.getUserId();
+    return userId ? readCachedPacks(userId, roomPacksScope(room.roomId)) : [];
+  });
+
+  useEffect(() => {
+    const userId = mx.getUserId();
+    if (userId) writeCachedPacks(userId, roomPacksScope(room.roomId), roomPacks);
+  }, [mx, room.roomId, roomPacks]);
 
   useStateEventCallback(
     mx,
@@ -166,7 +220,34 @@ export const useRoomImagePacks = (room: Room): ImagePack[] => {
 
 export const useRoomsImagePacks = (rooms: Room[]) => {
   const mx = useMatrixClient();
-  const [roomPacks, setRoomPacks] = useState(() => rooms.flatMap(getRoomImagePacks));
+  const [roomPacks, setRoomPacks] = useState<ImagePack[]>(() => {
+    const live = rooms.flatMap(getRoomImagePacks);
+    if (live.length > 0) return live;
+    const userId = mx.getUserId();
+    if (!userId) return [];
+    // Seed from cache for each room that has no live packs
+    return rooms.flatMap((room) => {
+      const livePacks = getRoomImagePacks(room);
+      if (livePacks.length > 0) return livePacks;
+      return readCachedPacks(userId, roomPacksScope(room.roomId));
+    });
+  });
+
+  useEffect(() => {
+    const userId = mx.getUserId();
+    if (!userId) return;
+    // Persist per-room — group packs by roomId and write each bucket
+    const byRoom = new Map<string, ImagePack[]>();
+    roomPacks.forEach((pack) => {
+      if (!pack.address) return;
+      const bucket = byRoom.get(pack.address.roomId) ?? [];
+      bucket.push(pack);
+      byRoom.set(pack.address.roomId, bucket);
+    });
+    byRoom.forEach((packs, roomId) => {
+      writeCachedPacks(userId, roomPacksScope(roomId), packs);
+    });
+  }, [mx, roomPacks]);
 
   useStateEventCallback(
     mx,

--- a/src/app/plugins/custom-emoji/imagePackCache.ts
+++ b/src/app/plugins/custom-emoji/imagePackCache.ts
@@ -1,0 +1,125 @@
+/**
+ * Persistent localStorage cache for image packs (emoji / stickers).
+ *
+ * Sliding Sync may not deliver `im.ponies.room_emotes` state events for rooms
+ * that aren't actively subscribed, so previously-seen packs would silently
+ * disappear on the next session.  This cache persists the serialised pack
+ * content keyed by (userId, scope) so the UI can show stale-but-usable packs
+ * while the live state catches up.
+ *
+ * Scopes
+ *   'user'           – the user's own im.ponies.user_emotes account-data pack
+ *   'global'         – all globally-enabled room packs via im.ponies.emote_rooms
+ *   'room:<roomId>'  – packs local to a specific room
+ */
+
+import { PackAddress } from './PackAddress';
+import { ImagePack } from './ImagePack';
+import { PackContent, PackImages } from './types';
+
+// --------------------------------------------------------------------------
+// Types stored in localStorage
+// --------------------------------------------------------------------------
+
+type CachedAddress = { roomId: string; stateKey: string };
+
+type CachedPackEntry = {
+  id: string;
+  content: PackContent;
+  address?: CachedAddress;
+};
+
+// --------------------------------------------------------------------------
+// Constants
+// --------------------------------------------------------------------------
+
+const STORAGE_KEY_PREFIX = 'sable:imgpk:v1';
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+function storageKey(userId: string, scope: string): string {
+  return `${STORAGE_KEY_PREFIX}:${userId}:${scope}`;
+}
+
+/** Reconstruct a plain `PackContent` from a live `ImagePack` instance. */
+function toPackContent(pack: ImagePack): PackContent {
+  const rawImages: PackImages = {};
+  pack.images.collection.forEach((img, shortcode) => {
+    rawImages[shortcode] = img.content;
+  });
+  return {
+    pack: pack.meta.content,
+    images: rawImages,
+  };
+}
+
+function deserializePacks(entries: CachedPackEntry[]): ImagePack[] {
+  return entries.map(({ id, content, address }) => {
+    const addr = address ? new PackAddress(address.roomId, address.stateKey) : undefined;
+    return new ImagePack(id, content, addr);
+  });
+}
+
+function serializePacks(packs: ImagePack[]): CachedPackEntry[] {
+  return packs
+    .filter((pack) => !pack.deleted)
+    .map((pack) => ({
+      id: pack.id,
+      content: toPackContent(pack),
+      address: pack.address
+        ? { roomId: pack.address.roomId, stateKey: pack.address.stateKey }
+        : undefined,
+    }));
+}
+
+// --------------------------------------------------------------------------
+// Public API
+// --------------------------------------------------------------------------
+
+/** Read cached packs for the given scope. Returns an empty array on any error. */
+export function readCachedPacks(userId: string, scope: string): ImagePack[] {
+  try {
+    const raw = localStorage.getItem(storageKey(userId, scope));
+    if (!raw) return [];
+    const entries = JSON.parse(raw);
+    if (!Array.isArray(entries)) return [];
+    return deserializePacks(entries as CachedPackEntry[]);
+  } catch {
+    return [];
+  }
+}
+
+/** Read a single cached pack for the given scope. Returns undefined on any error or miss. */
+export function readCachedPack(userId: string, scope: string): ImagePack | undefined {
+  return readCachedPacks(userId, scope)[0];
+}
+
+/** Persist packs for the given scope. Silently ignores storage errors. */
+export function writeCachedPacks(userId: string, scope: string, packs: ImagePack[]): void {
+  try {
+    const entries = serializePacks(packs);
+    if (entries.length === 0) {
+      localStorage.removeItem(storageKey(userId, scope));
+    } else {
+      localStorage.setItem(storageKey(userId, scope), JSON.stringify(entries));
+    }
+  } catch {
+    // private browsing / storage quota – silently ignore
+  }
+}
+
+/** Persist a single pack, or remove the entry when undefined. */
+export function writeCachedPack(userId: string, scope: string, pack: ImagePack | undefined): void {
+  writeCachedPacks(userId, scope, pack ? [pack] : []);
+}
+
+/** Scope string for the user's own pack. */
+export const userPackScope = () => 'user';
+
+/** Scope string for the global pack list. */
+export const globalPacksScope = () => 'global';
+
+/** Scope string for a specific room's packs. */
+export const roomPacksScope = (roomId: string) => `room:${roomId}`;

--- a/src/app/plugins/custom-emoji/index.ts
+++ b/src/app/plugins/custom-emoji/index.ts
@@ -5,3 +5,4 @@ export * from './PackImagesReader';
 export * from './ImagePack';
 export * from './types';
 export * from './utils';
+export * from './imagePackCache';

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -498,9 +498,18 @@ export const getLatestEditableEvt = (
   return undefined;
 };
 
-export const reactionOrEditEvent = (mEvent: MatrixEvent) =>
-  mEvent.getRelation()?.rel_type === RelationType.Annotation ||
-  mEvent.getRelation()?.rel_type === RelationType.Replace;
+export const reactionOrEditEvent = (mEvent: MatrixEvent): boolean => {
+  const relType = mEvent.getRelation()?.rel_type;
+  if (relType === RelationType.Annotation || relType === RelationType.Replace) return true;
+
+  // Sliding sync proxies may omit m.relates_to on the initial delivery of timeline
+  // events.  Detect edit events by the presence of m.new_content in the event
+  // content even when the relation metadata is absent, so they are filtered from
+  // the rendered timeline rather than falling through as unsupported messages.
+  if (mEvent.getContent()['m.new_content'] !== undefined) return true;
+
+  return false;
+};
 
 export const getMentionContent = (userIds: string[], room: boolean): IMentions => {
   const mMentions: IMentions = {};

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -136,11 +136,15 @@ const buildDefaultSubscription = (timelineLimit: number): MSC3575RoomSubscriptio
     [EventType.RoomTombstone, ''],
     [EventType.RoomJoinRules, ''],
     [EventType.RoomHistoryVisibility, ''],
+    [EventType.RoomPowerLevels, ''],
     [StateEvent.PoniesRoomEmotes, '*'],
     [StateEvent.RoomWidget, '*'],
     [StateEvent.GroupCallPrefix, '*'],
     [EventType.SpaceChild, '*'],
     [EventType.SpaceParent, '*'],
+    [StateEvent.RoomCosmeticsColor, '*'],
+    [StateEvent.RoomCosmeticsFont, '*'],
+    [StateEvent.RoomCosmeticsPronouns, '*'],
   ],
 });
 


### PR DESCRIPTION
## Summary

Three sliding-sync related fixes:

### 1. Cache emoji / image packs in localStorage

`imagePackCache.ts` — new localStorage cache for `ImagePack` instances, keyed by user/scope. All five hooks in `useImagePacks.ts` now seed from cache on cold-start and write through on change. Reduces reliance on sliding sync delivering custom emoji state before first render.

### 2. Prevent edit event leakage + align required_state

- `reactionOrEditEvent` now also detects edits via `m.new_content` presence as a fallback for when the sliding sync proxy strips `m.relates_to` — prevents stripped edit events from falling through and rendering as separate "Unsupported message" bubbles.
- `required_state` in `slidingSync.ts` extended with `m.room.power_levels` and cosmetics state events (`m.room.cosmetics.*`), which were previously missing from bundled subscriptions.

### 3. Re-render on non-live Replace events + guard empty `getContent()`

Two fixes for edited messages showing as "Broken/Unsupported message" until an unrelated live event triggered a re-render:

**`useRelationUpdate` hook** — listens for non-live `RoomEvent.Timeline` events with `rel_type=m.replace`. Sliding sync delivers bundled/historical edits as non-live events that are silently ignored by `useLiveEventArrive`; this hook triggers a shallow `setTimeline` update immediately when they arrive.

**Empty `getContent()` guard** — when the sliding sync proxy delivers a Replace event with `m.relates_to` intact but `m.new_content` absent, the SDK's `makeReplaced()` causes `mEvent.getContent()` to return `{}`. Passing `{}` to `RenderMessageContent` produces "Broken message". Fix: detect the empty result and fall back to `mEvent.getOriginalContent()`, which bypasses `makeReplaced` and returns the original unmodified content. `msgType` is now derived from the same resolved content object.