### PR TITLE
fix: Replace scheduled send chevron with tap & hold

### DIFF
--- a/.changeset/replace-send-chevron-mobile.md
+++ b/.changeset/replace-send-chevron-mobile.md
@@ -1,0 +1,9 @@
+---
+sable: patch
+---
+
+Changed scheduled send behavior on mobile. Removed the chevron next to the send button to make it more finger-friendly.
+
+Now, if your homeserver reports it, tapping and holding on the send button for 1 second will invoke the schedule picker to schedule a message.
+
+Desktop client is unaffected and retains the chevron so there is a visible indicator if scheduled send is supported.

--- a/.changeset/replace-send-chevron-mobile.md
+++ b/.changeset/replace-send-chevron-mobile.md
@@ -2,8 +2,4 @@
 sable: patch
 ---
 
-Changed scheduled send behavior on mobile. Removed the chevron next to the send button to make it more finger-friendly.
-
-Now, if your homeserver reports it, tapping and holding on the send button for 1 second will invoke the schedule picker to schedule a message.
-
-Desktop client is unaffected and retains the chevron so there is a visible indicator if scheduled send is supported.
+Mobile: changed scheduled send chevron to tap + hold

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -210,6 +210,8 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       selectedFiles.map((f) => f.file)
     );
     const uploadBoardHandlers = useRef<UploadBoardImperativeHandlers>();
+    const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isLongPress = useRef(false);
 
     const imagePackRooms: Room[] = useImagePackRooms(roomId, roomToParents);
 
@@ -943,8 +945,35 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
               />
               <Box display="Flex" alignItems="Center">
                 <IconButton
-                  onClick={submit}
+                  onClick={() => {
+                    if (isLongPress.current) {
+                      isLongPress.current = false;
+                      return;
+                    }
+                    submit();
+                  }}
                   onMouseDown={(e: MouseEvent) => e.preventDefault()}
+                  onPointerDown={() => {
+                    isLongPress.current = false;
+                    if (mobileOrTablet() && delayedEventsSupported) {
+                      longPressTimer.current = setTimeout(() => {
+                        isLongPress.current = true;
+                        setShowSchedulePicker(true);
+                      }, 1000);
+                    }
+                  }}
+                  onPointerUp={() => {
+                    if (longPressTimer.current !== null) {
+                      clearTimeout(longPressTimer.current);
+                      longPressTimer.current = null;
+                    }
+                  }}
+                  onPointerCancel={() => {
+                    if (longPressTimer.current !== null) {
+                      clearTimeout(longPressTimer.current);
+                      longPressTimer.current = null;
+                    }
+                  }}
                   variant={scheduledTime ? 'Primary' : 'SurfaceVariant'}
                   size="300"
                   radii="0"
@@ -952,7 +981,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                 >
                   <Icon src={scheduledTime ? Icons.Clock : Icons.Send} />
                 </IconButton>
-                {delayedEventsSupported && (
+                {delayedEventsSupported && !mobileOrTablet() && (
                   <IconButton
                     onClick={(evt: MouseEvent<HTMLButtonElement>) => {
                       setScheduleMenuAnchor(evt.currentTarget.getBoundingClientRect());


### PR DESCRIPTION
Additional fix for #113

Hides the chevron on mobile clients. Adds a 1 second tap and hold delay to scheduled send, skips some of the extra clicks on mobile to streamline the process.