### PR TITLE
chore: add knope changesets

### DIFF
--- a/.github/workflows/cloudflare-web-deploy.yml
+++ b/.github/workflows/cloudflare-web-deploy.yml
@@ -9,7 +9,7 @@ on:
       - '.github/actions/setup/**'
   push:
     tags:
-      - 'v*'
+      - 'sable/v*'
   workflow_dispatch:
 
 env:
@@ -57,7 +57,7 @@ jobs:
           label: production
 
   apply:
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/sable/v')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [dev]
     tags:
-      - 'v*'
+      - 'sable/v*'
 
 env:
   REGISTRY: ghcr.io
@@ -33,6 +33,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve release tag value
+        id: release_tag
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/sable/v* ]]; then
+            echo "value=${GITHUB_REF#refs/tags/sable/}" >> "$GITHUB_OUTPUT"
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
@@ -46,9 +58,9 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/dev' }}
 
             # git tags: semver breakdown
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/0.') }}
+            type=semver,pattern={{version}},value=${{ steps.release_tag.outputs.value }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.release_tag.outputs.value }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
+            type=semver,pattern={{major}},value=${{ steps.release_tag.outputs.value }},enable=${{ steps.release_tag.outputs.is_release == 'true' && !startsWith(steps.release_tag.outputs.value, 'v0.') }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,68 @@ Also, we use [ESLint](https://eslint.org/) for clean and stylistically consisten
 - `npm run typecheck`
 - `npm run knip`
 
+## Release notes and versioning (Knope)
+
+We use [Knope](https://knope.tech/) with the Knope GitHub Bot to manage change documentation and releases. The workflow configuration lives in [`knope.toml`](./knope.toml).
+
+If you have used [Changesets](https://github.com/changesets/changesets) before, Knope should feel very similar. The main difference is scope: Changesets is typically used for JavaScript repositories because it relies on `package.json`, while Knope is multi-language.
+
+If you prefer, you can install the Knope CLI yourself using the [official installation guide](https://knope.tech/installation/). This repo also exposes the CLI through npm scripts, so you can run `npm run knope -- <subcommand>` (for example: `npm run knope -- document-change`). Otherwise, this repo installs Knope for you via `postinstall`, so running `npm i` is enough.
+
+### Documenting a change
+
+A changeset is a Markdown file (usually in `.changeset/`) that captures intent to change: the semver bump (`major`, `minor`, `patch`) and the user-facing release note text. Knope later combines all pending changesets to decide version bumps and generate changelog entries.
+
+For user-facing pull requests, add one before requesting review.
+
+CLI paths:
+
+- `npm run document-change`
+- `npm run knope -- document-change`
+- `knope document-change` (if Knope is installed locally)
+
+All commands open an interactive prompt; fill in the package, change type, and short summary, then commit the generated change file in your PR.
+
+Alternatively, you can document the change manually by creating a change file:
+
+1. Create a file named `.changeset/fix-room-timeline-pagination.md` (or another descriptive file name).
+2. Copy and paste this Markdown into the file:
+
+```md
+---
+sable: patch
+---
+
+Short user-facing summary of the change.
+```
+
+3. Replace `patch` with one of: `major`, `minor`, `patch`, `docs`, or `note`.
+4. Edit the summary so it describes user-facing impact (not maintainer-only details).
+
+In this repo, the `internal` label skips Knope's documentation check (`[bot.checks].skip_labels`).
+
+Further reading:
+
+- https://github.com/knope-dev/changesets?tab=readme-ov-file#what-is-a-changeset
+- https://github.com/changesets/changesets/blob/main/docs/detailed-explanation.md
+
+### Release flow (GitHub Bot)
+
+Releases are driven by Knope Bot (`[bot.releases].enabled = true`):
+
+- The bot keeps an up-to-date release PR from `knope/release`.
+- Merging that bot release PR publishes the GitHub release.
+
+### Local validation and dry-run (optional)
+
+Maintainers can preview behavior without changing files:
+
+- `npm run knope -- release --dry-run`
+
+You can also validate the local Knope config with:
+
+- `npm run knope -- --validate`
+
 **For any query or design discussion, join our [Matrix room](https://matrix.to/#/#sable:sable.moe).**
 
 ## Helpful links

--- a/knip.json
+++ b/knip.json
@@ -6,6 +6,7 @@
     "type": true
   },
   "ignoreDependencies": ["buffer", "@element-hq/element-call-embedded", "workbox-precaching"],
+  "ignoreBinaries": ["knope"],
   "rules": {
     "exports": "off",
     "types": "off",

--- a/knope.toml
+++ b/knope.toml
@@ -1,0 +1,50 @@
+
+[package.sable]
+versioned_files = ["package.json", "package-lock.json"]
+changelog = "CHANGELOG.md"
+tag_prefix = "sable/"
+# assets = "marker for GitHub bot" // TODO: add this later once we have assets
+
+[changes]
+ignore_conventional_commits = true
+
+[package]
+extra_changelog_sections = [
+    { name = "Documentation", types = ["docs"] },
+    { name = "Notes", types = ["note"] }
+]
+
+[[workflows]]
+name = "release"
+help_text = "Prepare and create a new release (update changelog, bump version, create release)"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+
+[[workflows.steps]]
+type = "Command"
+command = 'git commit -m "chore: prepare release $version"'
+
+[[workflows.steps]]
+type = "Command"
+command = "git push"
+
+[[workflows.steps]]
+type = "Release"
+
+[[workflows]]
+name = "document-change"
+help_text = "Create a new change file to be included in the next release"
+
+[[workflows.steps]]
+type = "CreateChangeFile"
+
+[github]
+owner = "7w1"
+repo = "sable"
+
+[bot.releases]
+enabled = true
+
+[bot.checks]
+skip_labels = ["internal"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "sable",
       "version": "1.3.3",
+      "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "typecheck": "tsc",
-    "knip": "knip"
+    "knip": "knip",
+    "knope": "knope",
+    "document-change": "knope document-change",
+    "postinstall": "node scripts/install-knope.js"
   },
   "keywords": [],
   "author": "7w1",

--- a/scripts/install-knope.js
+++ b/scripts/install-knope.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+import { chmodSync, existsSync, mkdirSync, realpathSync, writeFileSync } from 'node:fs';
+import { join, dirname, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Buffer } from 'node:buffer';
+import { gunzipSync } from 'node:zlib';
+import { PrefixedLogger, createTextHelpers } from './utils/console-style.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const VERSION = '0.22.3';
+const TARGETS = {
+  'linux-x64': 'x86_64-unknown-linux-musl',
+  'linux-arm64': 'aarch64-unknown-linux-musl',
+  'darwin-x64': 'x86_64-apple-darwin',
+  'darwin-arm64': 'aarch64-apple-darwin',
+  'win32-x64': 'x86_64-pc-windows-msvc',
+};
+
+function parseKnopeVersion(output) {
+  const version = output?.trim().replace(/^knope\s+/, '');
+  return version || null;
+}
+
+function getKnopeVersion(command) {
+  const result = spawnSync(command, ['--version'], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    return null;
+  }
+  return parseKnopeVersion(result.stdout);
+}
+
+function readNullTerminatedString(buffer) {
+  const nulIndex = buffer.indexOf(0);
+  const end = nulIndex === -1 ? buffer.length : nulIndex;
+  return buffer.toString('utf8', 0, end);
+}
+
+function getTarBasename(entryName) {
+  const segments = entryName.split('/').filter(Boolean);
+  return segments.at(-1) ?? '';
+}
+
+function extractRegularFileFromTar(tarBuffer, expectedBasename) {
+  let offset = 0;
+  const regularEntries = [];
+
+  while (offset + 512 <= tarBuffer.length) {
+    const header = tarBuffer.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+
+    const name = readNullTerminatedString(header.subarray(0, 100));
+    const prefix = readNullTerminatedString(header.subarray(345, 500));
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const sizeOctal = readNullTerminatedString(header.subarray(124, 136)).trim();
+    const size = sizeOctal ? Number.parseInt(sizeOctal, 8) : 0;
+    const typeflag = header[156];
+    const isRegular = typeflag === 0 || typeflag === 48;
+
+    if (!Number.isFinite(size) || size < 0) {
+      throw new Error(`Invalid tar entry size for ${fullName || '<unknown>'}`);
+    }
+
+    const dataStart = offset + 512;
+    const dataEnd = dataStart + size;
+    if (dataEnd > tarBuffer.length) {
+      throw new Error('Corrupt tarball: entry exceeds archive size');
+    }
+
+    if (isRegular && fullName) {
+      regularEntries.push(fullName);
+      if (getTarBasename(fullName) === expectedBasename) {
+        return Buffer.from(tarBuffer.subarray(dataStart, dataEnd));
+      }
+    }
+
+    const alignedSize = Math.ceil(size / 512) * 512;
+    offset = dataStart + alignedSize;
+  }
+
+  throw new Error(
+    `Expected "${expectedBasename}" in tarball; found: ${regularEntries.join(', ') || 'none'}`
+  );
+}
+
+function getSystemKnopePath() {
+  const which = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['knope'], {
+    encoding: 'utf8',
+  });
+  if (which.status !== 0) {
+    return null;
+  }
+  return (
+    which.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? null
+  );
+}
+
+function isPathWithin(candidatePath, rootPath) {
+  const toComparablePath = (value) => {
+    const resolved = resolve(value);
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+  };
+  const candidate = toComparablePath(candidatePath);
+  const root = toComparablePath(rootPath);
+  return candidate === root || candidate.startsWith(`${root}${sep}`);
+}
+
+const logger = new PrefixedLogger('[postinstall:knope]');
+const { dim, red, green } = createTextHelpers({ useColor: logger.useColor });
+
+const target = TARGETS[`${process.platform}-${process.arch}`];
+if (!target) {
+  const supported = Object.keys(TARGETS).join(', ');
+  logger.error(
+    `${dim('Unsupported platform: ')}${red(`${process.platform}-${process.arch}`)}${dim('. Supported targets: ')}${supported}`
+  );
+  process.exit(1);
+}
+
+const bin = join(
+  __dirname,
+  `../node_modules/.bin/knope${process.platform === 'win32' ? '.exe' : ''}`
+);
+const localBinDir = join(__dirname, '../node_modules/.bin');
+mkdirSync(dirname(bin), { recursive: true });
+
+if (existsSync(bin)) {
+  const installed = getKnopeVersion(bin);
+  if (installed === VERSION) {
+    logger.info(`${dim('knope ')}${green(`v${VERSION}`)}${dim(' already installed')}`);
+    process.exit(0);
+  }
+  logger.info(
+    `${dim('Updating knope ')}${red(`v${installed ?? 'unknown'}`)}${dim(' -> ')}${green(`v${VERSION}`)}`
+  );
+}
+
+const systemKnopePath = getSystemKnopePath();
+if (systemKnopePath) {
+  const resolvedPath = (() => {
+    try {
+      return realpathSync(systemKnopePath);
+    } catch {
+      return systemKnopePath;
+    }
+  })();
+
+  if (!isPathWithin(resolvedPath, localBinDir)) {
+    const installed = getKnopeVersion(systemKnopePath);
+    if (installed === VERSION) {
+      logger.info(
+        `${dim('Using system knope ')}${green(`v${installed}`)}${dim(', skipping download')}`
+      );
+      process.exit(0);
+    }
+    if (installed) {
+      logger.info(
+        `${dim('Found system knope ')}${red(`v${installed}`)}${dim('; installing pinned ')}${green(`v${VERSION}`)}${dim('. Consider updating your system knope.')}`
+      );
+    }
+  }
+}
+
+const url = `https://github.com/knope-dev/knope/releases/download/knope%2Fv${VERSION}/knope-${target}.tgz`;
+logger.info(
+  `${dim('Downloading knope ')}${green(`v${VERSION}`)}${dim(' for ')}${target}${dim('...')}`
+);
+const response = await fetch(url);
+if (!response.ok) {
+  throw new Error(`Failed to download knope: ${response.status} ${response.statusText}`);
+}
+const gzipBytes = Buffer.from(await response.arrayBuffer());
+const tarBytes = gunzipSync(gzipBytes);
+const expectedBinaryName = process.platform === 'win32' ? 'knope.exe' : 'knope';
+const knopeBinary = extractRegularFileFromTar(tarBytes, expectedBinaryName);
+writeFileSync(bin, knopeBinary);
+chmodSync(bin, 0o755);
+const installed = getKnopeVersion(bin);
+if (installed !== VERSION) {
+  throw new Error(
+    `Installed knope version mismatch: expected ${VERSION}, got ${installed ?? 'unknown'}`
+  );
+}
+logger.info(`${dim('Installed knope ')}${green(`v${installed}`)}`);

--- a/scripts/normalize-imports.js
+++ b/scripts/normalize-imports.js
@@ -5,6 +5,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import ts from 'typescript';
+import { createTextHelpers } from './utils/console-style.js';
 
 const DEFAULT_ROOTS = ['src'];
 const SKIP_DIRS = new Set(['.git', '.hg', '.svn', 'node_modules', 'dist', 'coverage']);
@@ -13,23 +14,6 @@ const MATRIX_IMPORT_BOUNDARY_FILES = new Set([
   path.normalize('src/types/matrix-sdk.ts'),
   path.normalize('src/types/matrix-sdk-events.d.ts'),
 ]);
-const ANSI = {
-  reset: '\x1b[0m',
-  red: '\x1b[31m',
-  green: '\x1b[32m',
-  dim: '\x1b[2m',
-};
-
-function shouldUseColor() {
-  if (process.env.NO_COLOR !== undefined) return false;
-  if (process.env.FORCE_COLOR && process.env.FORCE_COLOR !== '0') return true;
-  return Boolean(process.stdout.isTTY);
-}
-
-function styleText(text, color, enabled) {
-  if (!enabled) return text;
-  return `${color}${text}${ANSI.reset}`;
-}
 
 function toPosix(inputPath) {
   return inputPath.split(path.sep).join('/');
@@ -251,7 +235,7 @@ async function main() {
   const projectRoot = process.cwd();
   const { write, roots } = parseArgs(process.argv.slice(2));
   const aliases = await loadAliasMap(path.join(projectRoot, 'vite.config.ts'), projectRoot);
-  const useColor = shouldUseColor();
+  const { dim, red, green } = createTextHelpers();
 
   if (aliases.length === 0) {
     throw new Error('No aliases found in vite.config.ts');
@@ -311,10 +295,10 @@ async function main() {
     a.file === b.file ? a.from.localeCompare(b.from) : a.file.localeCompare(b.file)
   );
   displayRows.forEach((row) => {
-    const fileLabel = styleText(row.file, ANSI.dim, useColor);
-    const fromLabel = styleText(`"${row.from}"`, ANSI.red, useColor);
-    const arrowLabel = styleText(' -> ', ANSI.dim, useColor);
-    const toLabel = styleText(`"${row.to}"`, ANSI.green, useColor);
+    const fileLabel = dim(row.file);
+    const fromLabel = red(`"${row.from}"`);
+    const arrowLabel = dim(' -> ');
+    const toLabel = green(`"${row.to}"`);
     console.log(`${fileLabel}: ${fromLabel}${arrowLabel}${toLabel}`);
   });
 

--- a/scripts/utils/console-style.js
+++ b/scripts/utils/console-style.js
@@ -1,0 +1,55 @@
+/* eslint-disable no-console */
+import process from 'node:process';
+
+export const ANSI = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  dim: '\x1b[2m',
+};
+
+export function shouldUseColor() {
+  if (process.env.NO_COLOR !== undefined) return false;
+  if (process.env.FORCE_COLOR && process.env.FORCE_COLOR !== '0') return true;
+  return Boolean(process.stdout.isTTY);
+}
+
+export function styleText(text, color, enabled) {
+  if (!enabled) return text;
+  return `${color}${text}${ANSI.reset}`;
+}
+
+export function createTextHelpers(options = {}) {
+  const useColor = options.useColor ?? shouldUseColor();
+  const style = (text, color) => styleText(text, color, useColor);
+  const dim = (text) => styleText(text, ANSI.dim, useColor);
+  const red = (text) => styleText(text, ANSI.red, useColor);
+  const green = (text) => styleText(text, ANSI.green, useColor);
+  return {
+    useColor,
+    style,
+    dim,
+    red,
+    green,
+  };
+}
+
+export class PrefixedLogger {
+  constructor(prefix, options = {}) {
+    this.prefix = prefix;
+    this.useColor = options.useColor ?? shouldUseColor();
+    this.prefixColor = options.prefixColor ?? ANSI.dim;
+  }
+
+  withPrefix(message) {
+    return `${styleText(this.prefix, this.prefixColor, this.useColor)} ${message}`;
+  }
+
+  info(message) {
+    console.log(this.withPrefix(message));
+  }
+
+  error(message) {
+    console.error(this.withPrefix(message));
+  }
+}


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


Fixes #99 

I choose [Knope](https://knope.tech/) over [Changesets](https://github.com/changesets/changesets) due to the multi language support. This will become useful once #28 lands and we might up making our own rust crates or packages for certain features, that way it can be used externally as well.

One thing to note, this current setup will publish git tags as monorepo style, meaning `<package-name>/v1.0.0` for example. I went with `sable/v1.0.0` for the normal releases.

This bot is required to be installed with this setup: https://github.com/marketplace/knope-bot

alternatively I can basically remake the knope bot's functionality via github actions if that's desired instead. 

also Knope allows some customization but I kept it default for now (I can update it if desired):
- https://knope.tech/recipes/customizing-release-notes/
- https://knope.tech/reference/knope-bot-github-app/features/#customizing-pull-request-title

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
