### PR TITLE
CHANGE handling of extended profile data (bio and pronouns)

### DIFF
--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -546,7 +546,7 @@ function ProfileExtended({ profile, userId }: ProfileProps) {
             handleSaveField('io.fsky.nyx.pronouns', p);
             // also save it under the MSC4247 key for better compatibility with other clients,
             // even if it's NOT finalized yet, to maximize the chance of pronouns showing up if they're set.
-            handleSaveField('m.pronouns', p);
+            handleSaveField('org.matrix.msc4247.pronouns', p);
           }}
         />
       </SequenceCard>

--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -569,10 +569,14 @@ function ProfileExtended({ profile, userId }: ProfileProps) {
           value={
             profile.extended?.['moe.sable.app.bio'] ||
             profile.extended?.['chat.commet.profile_bio'] ||
+            // setting it also as extera about for better compatibility with existing profiles
+            profile.extended?.['xyz.extera.about'] ||
             profile.bio
           }
           onSave={(htmlBio) => {
             handleSaveField('moe.sable.app.bio', htmlBio);
+            // remove html tags for the plaintext version for extera about
+            handleSaveField('xyz.extera.about', htmlBio.replace(/<[^>]*>/g, ''));
 
             const cleanedHtml = htmlBio.replace(/<br\/><\/blockquote>/g, '</blockquote>');
             handleSaveField('chat.commet.profile_bio', {

--- a/src/app/features/settings/account/Profile.tsx
+++ b/src/app/features/settings/account/Profile.tsx
@@ -542,7 +542,12 @@ function ProfileExtended({ profile, userId }: ProfileProps) {
       >
         <PronounEditor
           current={pronouns}
-          onSave={(p) => handleSaveField('io.fsky.nyx.pronouns', p)}
+          onSave={(p) => {
+            handleSaveField('io.fsky.nyx.pronouns', p);
+            // also save it under the MSC4247 key for better compatibility with other clients,
+            // even if it's NOT finalized yet, to maximize the chance of pronouns showing up if they're set.
+            handleSaveField('m.pronouns', p);
+          }}
         />
       </SequenceCard>
       <SequenceCard

--- a/src/app/hooks/useUserProfile.ts
+++ b/src/app/hooks/useUserProfile.ts
@@ -30,7 +30,7 @@ const normalizeInfo = (info: any): UserProfile => {
     'displayname',
     'io.fsky.nyx.pronouns',
     // MSC4247 user pronouns key, for when it eventually gets accepted
-    'm.pronouns',
+    'org.matrix.msc4247.pronouns',
     'us.cloke.msc4175.tz',
     'm.tz',
     'moe.sable.app.bio',
@@ -53,7 +53,7 @@ const normalizeInfo = (info: any): UserProfile => {
     avatarUrl: info.avatar_url,
     displayName: info.displayname,
     // prioritize the MSC4247 key but fall back to the older fsky one, to maximize the chance of showing pronouns if they're set.
-    pronouns: info['m.pronouns'] || info['io.fsky.nyx.pronouns'],
+    pronouns: info['org.matrix.msc4247.pronouns'] || info['io.fsky.nyx.pronouns'],
     timezone: info['us.cloke.msc4175.tz'] || info['m.tz'],
     // prefer sable bio but fall back to commet and extera about, which are more widely used at the moment, to maximize the chance of showing something useful.
     bio: info['moe.sable.app.bio'] || info['chat.commet.profile_bio'] || info['xyz.extera.about'],

--- a/src/app/hooks/useUserProfile.ts
+++ b/src/app/hooks/useUserProfile.ts
@@ -35,6 +35,8 @@ const normalizeInfo = (info: any): UserProfile => {
     'm.tz',
     'moe.sable.app.bio',
     'chat.commet.profile_bio',
+    // for more compatibility with existing profiles, even if it's not ideal.
+    'xyz.extera.about',
     'chat.commet.profile_banner',
     'chat.commet.profile_status',
     'moe.sable.app.name_color',
@@ -53,7 +55,8 @@ const normalizeInfo = (info: any): UserProfile => {
     // prioritize the MSC4247 key but fall back to the older fsky one, to maximize the chance of showing pronouns if they're set.
     pronouns: info['m.pronouns'] || info['io.fsky.nyx.pronouns'],
     timezone: info['us.cloke.msc4175.tz'] || info['m.tz'],
-    bio: info['moe.sable.app.bio'] || info['chat.commet.profile_bio'],
+    // prefer sable bio but fall back to commet and extera about, which are more widely used at the moment, to maximize the chance of showing something useful.
+    bio: info['moe.sable.app.bio'] || info['chat.commet.profile_bio'] || info['xyz.extera.about'],
     status: info['chat.commet.profile_status'],
     bannerUrl: info['chat.commet.profile_banner'],
     nameColor: info['moe.sable.app.name_color'],

--- a/src/app/hooks/useUserProfile.ts
+++ b/src/app/hooks/useUserProfile.ts
@@ -29,6 +29,8 @@ const normalizeInfo = (info: any): UserProfile => {
     'avatar_url',
     'displayname',
     'io.fsky.nyx.pronouns',
+    // MSC4247 user pronouns key, for when it eventually gets accepted
+    'm.pronouns',
     'us.cloke.msc4175.tz',
     'm.tz',
     'moe.sable.app.bio',
@@ -48,7 +50,8 @@ const normalizeInfo = (info: any): UserProfile => {
   return {
     avatarUrl: info.avatar_url,
     displayName: info.displayname,
-    pronouns: info['io.fsky.nyx.pronouns'],
+    // prioritize the MSC4247 key but fall back to the older fsky one, to maximize the chance of showing pronouns if they're set.
+    pronouns: info['m.pronouns'] || info['io.fsky.nyx.pronouns'],
     timezone: info['us.cloke.msc4175.tz'] || info['m.tz'],
     bio: info['moe.sable.app.bio'] || info['chat.commet.profile_bio'],
     status: info['chat.commet.profile_status'],


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

also setting and reading the pronouns set under the key definied in https://github.com/matrix-org/matrix-spec-proposals/pull/4247 (even if not finalized yet, for the eventual adoption of it) and for broader compaitibility also setting the bio in the about field extera uses

#### show that it works

##### before the change

<img width="auto" height="300" alt="Capture-2026-03-05-132354" src="https://github.com/user-attachments/assets/6f39452e-5c94-4ddf-904f-428a59c702d8" />
<img width="auto" height="300" alt="Capture-2026-03-05-132416" src="https://github.com/user-attachments/assets/3bcd08c3-1d30-4ce9-873a-411f6f330ef1" />

*note that the data in the profile is inconsistent in the profile json shown, which I wanted to prevent with this pr*

#### after the change

<img width="auto" height="300" alt="image" src="https://github.com/user-attachments/assets/e046f496-e11a-4b89-9f64-f62dbf5c70a5" />
<img width="auto" height="300" alt="image" src="https://github.com/user-attachments/assets/6974dca1-dd1b-4421-a94e-6e34cf9251d0" />

*the pronoun sets are now consistent with each other*

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
