### PR TITLE
Text quick react + reaction permission fixes

### DIFF
--- a/.changeset/pr149_react_permission_fixes.md
+++ b/.changeset/pr149_react_permission_fixes.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+You can now remove your own reactions even if you don't have the permission to add new ones, as long as you are able to delete your own events (messages).

--- a/.changeset/pr149_text_quick_react.md
+++ b/.changeset/pr149_text_quick_react.md
@@ -1,0 +1,5 @@
+---
+sable: minor
+---
+
+Add a method of quickly adding a new text reaction to the latest message, just like emote quick react, using the prefix `+#`

--- a/src/app/components/editor/autocomplete/AutocompleteMenu.css.tsx
+++ b/src/app/components/editor/autocomplete/AutocompleteMenu.css.tsx
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
-import { DefaultReset, config } from 'folds';
+import { DefaultReset, color, config } from 'folds';
 
 export const AutocompleteMenuBase = style([
   DefaultReset,
@@ -32,4 +32,9 @@ export const AutocompleteMenu = style([
 export const AutocompleteMenuHeader = style([
   DefaultReset,
   { padding: `0 ${config.space.S300}`, flexShrink: 0 },
+]);
+
+export const AutocompleteNotice = style([
+  AutocompleteMenuHeader,
+  { color: color.SurfaceVariant.OnContainer },
 ]);

--- a/src/app/components/editor/autocomplete/AutocompleteMenu.tsx
+++ b/src/app/components/editor/autocomplete/AutocompleteMenu.tsx
@@ -6,6 +6,7 @@ import { Header, Menu, Scroll, config } from 'folds';
 import { preventScrollWithArrowKey, stopPropagation } from '$utils/keyboard';
 import { useAlive } from '$hooks/useAlive';
 import * as css from './AutocompleteMenu.css';
+import { BaseAutocompleteMenu } from './BaseAutocompleteMenu';
 
 type AutocompleteMenuProps = {
   requestClose: () => void;
@@ -23,30 +24,28 @@ export function AutocompleteMenu({ headerContent, requestClose, children }: Auto
   };
 
   return (
-    <div className={css.AutocompleteMenuBase}>
-      <div className={css.AutocompleteMenuContainer}>
-        <FocusTrap
-          focusTrapOptions={{
-            initialFocus: false,
-            onPostDeactivate: handleDeactivate,
-            returnFocusOnDeactivate: false,
-            clickOutsideDeactivates: true,
-            allowOutsideClick: true,
-            isKeyForward: (evt: KeyboardEvent) => isKeyHotkey('arrowdown', evt),
-            isKeyBackward: (evt: KeyboardEvent) => isKeyHotkey('arrowup', evt),
-            escapeDeactivates: stopPropagation,
-          }}
-        >
-          <Menu className={css.AutocompleteMenu}>
-            <Header className={css.AutocompleteMenuHeader} size="400">
-              {headerContent}
-            </Header>
-            <Scroll style={{ flexGrow: 1 }} onKeyDown={preventScrollWithArrowKey}>
-              <div style={{ padding: config.space.S200 }}>{children}</div>
-            </Scroll>
-          </Menu>
-        </FocusTrap>
-      </div>
-    </div>
+    <BaseAutocompleteMenu>
+      <FocusTrap
+        focusTrapOptions={{
+          initialFocus: false,
+          onPostDeactivate: handleDeactivate,
+          returnFocusOnDeactivate: false,
+          clickOutsideDeactivates: true,
+          allowOutsideClick: true,
+          isKeyForward: (evt: KeyboardEvent) => isKeyHotkey('arrowdown', evt),
+          isKeyBackward: (evt: KeyboardEvent) => isKeyHotkey('arrowup', evt),
+          escapeDeactivates: stopPropagation,
+        }}
+      >
+        <Menu className={css.AutocompleteMenu}>
+          <Header className={css.AutocompleteMenuHeader} size="400">
+            {headerContent}
+          </Header>
+          <Scroll style={{ flexGrow: 1 }} onKeyDown={preventScrollWithArrowKey}>
+            <div style={{ padding: config.space.S200 }}>{children}</div>
+          </Scroll>
+        </Menu>
+      </FocusTrap>
+    </BaseAutocompleteMenu>
   );
 }

--- a/src/app/components/editor/autocomplete/AutocompleteNotice.tsx
+++ b/src/app/components/editor/autocomplete/AutocompleteNotice.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+import { Header, Menu } from 'folds';
+import { BaseAutocompleteMenu } from './BaseAutocompleteMenu';
+import * as css from './AutocompleteMenu.css';
+
+type AutocompleteNoticeProps = {
+  children: ReactNode;
+};
+export function AutocompleteNotice({ children }: AutocompleteNoticeProps) {
+  return (
+    <BaseAutocompleteMenu>
+      <Menu className={css.AutocompleteMenu}>
+        <Header className={css.AutocompleteNotice} size="400">
+          {children}
+        </Header>
+      </Menu>
+    </BaseAutocompleteMenu>
+  );
+}

--- a/src/app/components/editor/autocomplete/BaseAutocompleteMenu.tsx
+++ b/src/app/components/editor/autocomplete/BaseAutocompleteMenu.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import * as css from './AutocompleteMenu.css';
+
+type BaseAutocompleteMenuProps = {
+  children: ReactNode;
+};
+export function BaseAutocompleteMenu({ children }: BaseAutocompleteMenuProps) {
+  return (
+    <div className={css.AutocompleteMenuBase}>
+      <div className={css.AutocompleteMenuContainer}>{children}</div>
+    </div>
+  );
+}

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -144,6 +144,10 @@ import {
 import { timeHourMinute, timeDayMonthYear } from '$utils/time';
 import { stopPropagation } from '$utils/keyboard';
 import { MessageEvent } from '$types/matrix/room';
+import { usePowerLevelsContext } from '$hooks/usePowerLevels';
+import { useRoomCreators } from '$hooks/useRoomCreators';
+import { useRoomPermissions } from '$hooks/useRoomPermissions';
+import { AutocompleteNotice } from '$components/editor/autocomplete/AutocompleteNotice';
 import { SchedulePickerDialog } from './schedule-send';
 import * as css from './schedule-send/SchedulePickerDialog.css';
 import {
@@ -193,6 +197,11 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     const emojiBtnRef = useRef<HTMLButtonElement>(null);
     const roomToParents = useAtomValue(roomToParentsAtom);
     const nicknames = useAtomValue(nicknamesAtom);
+
+    const powerLevels = usePowerLevelsContext();
+    const creators = useRoomCreators(room);
+    const permissions = useRoomPermissions(creators, powerLevels);
+    const canSendReaction = permissions.event(MessageEvent.Reaction, mx.getSafeUserId());
 
     const [msgDraft, setMsgDraft] = useAtom(roomIdToMsgDraftAtomFamily(roomId));
     const [replyDraft, setReplyDraft] = useAtom(roomIdToReplyDraftAtomFamily(roomId));
@@ -716,16 +725,21 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
             requestClose={handleCloseAutocomplete}
           />
         )}
-        {autocompleteQuery?.prefix === AutocompletePrefix.Reaction && (
-          <EmoticonAutocomplete
-            title={`React with :${autocompleteQuery.text}`}
-            imagePackRooms={imagePackRooms}
-            editor={editor}
-            query={autocompleteQuery}
-            requestClose={handleCloseAutocomplete}
-            onEmoticonSelected={handleReactionAutocomplete}
-          />
-        )}
+        {autocompleteQuery?.prefix === AutocompletePrefix.Reaction &&
+          (canSendReaction ? (
+            <EmoticonAutocomplete
+              title={`React with :${autocompleteQuery.text}`}
+              imagePackRooms={imagePackRooms}
+              editor={editor}
+              query={autocompleteQuery}
+              requestClose={handleCloseAutocomplete}
+              onEmoticonSelected={handleReactionAutocomplete}
+            />
+          ) : (
+            <AutocompleteNotice>
+              <Text align="Center">You do not have permission to send reactions in this room</Text>
+            </AutocompleteNotice>
+          ))}
         {autocompleteQuery?.prefix === AutocompletePrefix.Command && (
           <CommandAutocomplete
             room={room}

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -225,6 +225,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     const [toolbar, setToolbar] = useSetting(settingsAtom, 'editorToolbar');
     const [autocompleteQuery, setAutocompleteQuery] =
       useState<AutocompleteQuery<AutocompletePrefix>>();
+    const [isQuickTextReact, setQuickTextReact] = useState(false);
 
     const sendTypingStatus = useTypingStatusUpdater(mx, roomId);
 
@@ -404,6 +405,41 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       );
     };
 
+    const handleCloseAutocomplete = useCallback(() => {
+      setAutocompleteQuery(undefined);
+      ReactEditor.focus(editor);
+    }, [editor]);
+
+    const handleQuickReact = useCallback(
+      (key: string, shortcode?: string) => {
+        if (key.length > 0) {
+          const lastMessage = room
+            .getLiveTimeline()
+            .getEvents()
+            .findLast((event) =>
+              (
+                [
+                  MessageEvent.RoomMessage,
+                  MessageEvent.RoomMessageEncrypted,
+                  MessageEvent.Sticker,
+                ] as string[]
+              ).includes(event.getType())
+            );
+          const lastMessageId = lastMessage?.getId();
+
+          if (lastMessageId) {
+            toggleReaction(mx, room, lastMessageId, key, shortcode);
+          }
+        }
+
+        resetEditor(editor);
+        resetEditorHistory(editor);
+        sendTypingStatus(false);
+        handleCloseAutocomplete();
+      },
+      [editor, handleCloseAutocomplete, mx, room, sendTypingStatus]
+    );
+
     const submit = useCallback(async () => {
       uploadBoardHandlers.current?.handleSend();
 
@@ -417,6 +453,12 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         })
       );
       let msgType = MsgType.Text;
+
+      // quick text react
+      if (canSendReaction && plainText.startsWith('+#')) {
+        handleQuickReact(plainText.substring(2));
+        return;
+      }
 
       if (commandName) {
         plainText = trimCommand(commandName, plainText);
@@ -517,21 +559,23 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         });
       }
     }, [
+      editor,
+      isMarkdown,
+      canSendReaction,
       mx,
       roomId,
-      room,
-      editor,
       replyDraft,
-      sendTypingStatus,
-      setReplyDraft,
-      isMarkdown,
-      commands,
       scheduledTime,
-      setScheduledTime,
-      isEncrypted,
-      queryClient,
       editingScheduledDelayId,
+      handleQuickReact,
+      commands,
+      sendTypingStatus,
+      queryClient,
+      setReplyDraft,
+      isEncrypted,
       setEditingScheduledDelayId,
+      setScheduledTime,
+      room,
     ]);
 
     const handleKeyDown: KeyboardEventHandler = useCallback(
@@ -568,13 +612,28 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           sendTypingStatus(!isEmptyEditor(editor));
         }
 
+        const firstPosition = Editor.start(editor, []);
+        const secondChar = Editor.after(editor, firstPosition, {
+          distance: 2,
+          unit: 'character',
+        });
+        const quickReactPrefix = Editor.string(
+          editor,
+          Editor.range(editor, firstPosition, secondChar)
+        );
+        if (quickReactPrefix === '+#') {
+          setQuickTextReact(true);
+          setAutocompleteQuery(undefined);
+          return;
+        }
+        setQuickTextReact(false);
+
         const prevWordRange = getPrevWorldRange(editor);
         if (!prevWordRange) {
           setAutocompleteQuery(undefined);
           return;
         }
 
-        const firstPosition = Editor.start(editor, []);
         const isRangeAtBeginning = !Point.isAfter(Range.start(prevWordRange), firstPosition);
         const query =
           (isRangeAtBeginning
@@ -586,36 +645,6 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       },
       [editor, sendTypingStatus, hideActivity]
     );
-
-    const handleCloseAutocomplete = useCallback(() => {
-      setAutocompleteQuery(undefined);
-      ReactEditor.focus(editor);
-    }, [editor]);
-
-    const handleReactionAutocomplete = (key: string, shortcode: string) => {
-      const lastMessage = room
-        .getLiveTimeline()
-        .getEvents()
-        .findLast((event) =>
-          (
-            [
-              MessageEvent.RoomMessage,
-              MessageEvent.RoomMessageEncrypted,
-              MessageEvent.Sticker,
-            ] as string[]
-          ).includes(event.getType())
-        );
-      const lastMessageId = lastMessage?.getId();
-
-      if (lastMessageId) {
-        toggleReaction(mx, room, lastMessageId, key, shortcode);
-      }
-
-      resetEditor(editor);
-      resetEditorHistory(editor);
-      sendTypingStatus(false);
-      handleCloseAutocomplete();
-    };
 
     const handleEmoticonSelect = (key: string, shortcode: string) => {
       editor.insertNode(createEmoticonElement(key, shortcode));
@@ -733,11 +762,11 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
               editor={editor}
               query={autocompleteQuery}
               requestClose={handleCloseAutocomplete}
-              onEmoticonSelected={handleReactionAutocomplete}
+              onEmoticonSelected={handleQuickReact}
             />
           ) : (
             <AutocompleteNotice>
-              <Text align="Center">You do not have permission to send reactions in this room</Text>
+              You do not have permission to send reactions in this room
             </AutocompleteNotice>
           ))}
         {autocompleteQuery?.prefix === AutocompletePrefix.Command && (
@@ -748,6 +777,14 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
             requestClose={handleCloseAutocomplete}
           />
         )}
+        {isQuickTextReact &&
+          (canSendReaction ? (
+            <AutocompleteNotice>Sending as text reaction to the latest message</AutocompleteNotice>
+          ) : (
+            <AutocompleteNotice>
+              You do not have permission to send reactions in this room
+            </AutocompleteNotice>
+          ))}
         <CustomEditor
           editableName="RoomInput"
           editor={editor}

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1327,6 +1327,7 @@ export function RoomTimeline({
                   relations={reactionRelations}
                   mEventId={mEventId}
                   canSendReaction={canSendReaction}
+                  canDeleteOwn={canDeleteOwn}
                   onReactionToggle={handleReactionToggle}
                 />
               )
@@ -1413,6 +1414,7 @@ export function RoomTimeline({
                   relations={reactionRelations}
                   mEventId={mEventId}
                   canSendReaction={canSendReaction}
+                  canDeleteOwn={canDeleteOwn}
                   onReactionToggle={handleReactionToggle}
                 />
               )
@@ -1534,6 +1536,7 @@ export function RoomTimeline({
                   relations={reactionRelations}
                   mEventId={mEventId}
                   canSendReaction={canSendReaction}
+                  canDeleteOwn={canDeleteOwn}
                   onReactionToggle={handleReactionToggle}
                 />
               )

--- a/src/app/features/room/message/Reactions.tsx
+++ b/src/app/features/room/message/Reactions.tsx
@@ -27,12 +27,25 @@ import * as css from './styles.css';
 export type ReactionsProps = {
   room: Room;
   mEventId: string;
-  canSendReaction?: boolean;
+  canSendReaction: boolean;
+  canDeleteOwn: boolean;
   relations: Relations;
   onReactionToggle: (targetEventId: string, key: string, shortcode?: string) => void;
 };
 export const Reactions = as<'div', ReactionsProps>(
-  ({ className, room, relations, mEventId, canSendReaction, onReactionToggle, ...props }, ref) => {
+  (
+    {
+      className,
+      room,
+      relations,
+      mEventId,
+      canSendReaction,
+      canDeleteOwn,
+      onReactionToggle,
+      ...props
+    },
+    ref
+  ) => {
     const mx = useMatrixClient();
     const useAuthentication = useMediaAuthentication();
     const [viewer, setViewer] = useState<boolean | string>(false);
@@ -63,6 +76,7 @@ export const Reactions = as<'div', ReactionsProps>(
           if (rEvents.length === 0 || typeof key !== 'string') return null;
           const myREvent = myUserId ? rEvents.find(factoryEventSentBy(myUserId)) : undefined;
           const isPressed = !!myREvent?.getRelation();
+          const canToggle = isPressed ? canDeleteOwn : canSendReaction;
 
           return (
             <TooltipProvider
@@ -85,9 +99,9 @@ export const Reactions = as<'div', ReactionsProps>(
                   mx={mx}
                   reaction={key}
                   count={events.size}
-                  onClick={canSendReaction ? () => onReactionToggle(mEventId, key) : undefined}
+                  onClick={canToggle ? () => onReactionToggle(mEventId, key) : undefined}
                   onContextMenu={handleViewReaction}
-                  aria-disabled={!canSendReaction}
+                  aria-disabled={!canToggle}
                   useAuthentication={useAuthentication}
                 />
               )}


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

this pr adds the `+#` prefix (similar to `+:`) for quick text reactions
unlike emote reactions, quick text reactions are not bound to the autocomplete prompt and so you can include spaces in your text reactions

[text_react.webm](https://github.com/user-attachments/assets/0655bbf6-551b-4ca0-a497-610950d453b0)

it also fixes the permission checks for reactions, showing a notice when attempting to quick react without permissions, and allowing users to redact their own reactions even if they do not have reaction permissions, as long they can delete own events

<img width="429" height="106" alt="image" src="https://github.com/user-attachments/assets/e7d9078f-c7bb-4765-8b8d-0dadf7b53aea" />

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
