### PR TITLE
Hide delete modal after message deletion

### DIFF
--- a/.changeset/hide_delete_modal_after_message_deletion.md
+++ b/.changeset/hide_delete_modal_after_message_deletion.md
@@ -2,31 +2,4 @@
 default: patch
 ---
 
-# Hide delete modal after message deletion
-
-#151 by @7w1
-
-<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->
-
-### Description
-
-<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
-
-Hides the delete modal by properly calling onClose() after a successful deletion.
-
-Fixes #150
-
-#### Type of change
-
-- [x] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-
-### Checklist:
-
-- [x] My code follows the style guidelines of this project
-- [x] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [x] My changes generate no new warnings
+Hide delete modal after successfully deleting a message.

--- a/.changeset/hide_delete_modal_after_message_deletion.md
+++ b/.changeset/hide_delete_modal_after_message_deletion.md
@@ -1,0 +1,32 @@
+---
+default: patch
+---
+
+# Hide delete modal after message deletion
+
+#151 by @7w1
+
+<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->
+
+### Description
+
+<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
+
+Hides the delete modal by properly calling onClose() after a successful deletion.
+
+Fixes #150
+
+#### Type of change
+
+- [x] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+### Checklist:
+
+- [x] My code follows the style guidelines of this project
+- [x] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [x] My changes generate no new warnings

--- a/src/app/components/message/modals/MessageDelete.tsx
+++ b/src/app/components/message/modals/MessageDelete.tsx
@@ -1,4 +1,4 @@
-import { FormEventHandler, MouseEvent, useCallback } from 'react';
+import { FormEventHandler, MouseEvent, useCallback, useEffect } from 'react';
 import { Room, MatrixEvent } from '$types/matrix-sdk';
 import { useSetAtom } from 'jotai';
 import {
@@ -64,6 +64,12 @@ export function MessageDeleteInternal({ room, mEvent, onClose }: MessageDeleteIn
       [mx, room]
     )
   );
+
+  useEffect(() => {
+    if (deleteState.status === AsyncStatus.Success) {
+      onClose();
+    }
+  }, [deleteState.status, onClose]);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (evt) => {
     evt.preventDefault();


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Hides the delete modal by properly calling onClose() after a successful deletion.

Fixes #150 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
