### PR TITLE
style(message): use Chip for failed-send retry and delete buttons

### DIFF
--- a/.changeset/message_send_button_chips.md
+++ b/.changeset/message_send_button_chips.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Failed message retry and delete actions now use Chip buttons for visual consistency with the rest of the interface.

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -1,6 +1,7 @@
 import {
   Avatar,
   Box,
+  Chip,
   Icon,
   IconButton,
   Icons,
@@ -520,18 +521,19 @@ function MessageInternal(
             Failed to send.
           </Text>
           {canResend && (
-            <button type="button" className={css.SendStatusButton} onClick={handleResendClick}>
-              Retry
-            </button>
+            <Chip type="button" variant="Primary" radii="Pill" outlined onClick={handleResendClick}>
+              <Text size="B300">Retry</Text>
+            </Chip>
           )}
           {canDeleteFailedSend && (
-            <button
+            <Chip
               type="button"
-              className={css.SendStatusButton}
+              variant="Critical"
+              radii="Pill"
               onClick={handleDeleteFailedSendClick}
             >
-              Delete
-            </button>
+              <Text size="B300">Delete</Text>
+            </Chip>
           )}
         </Box>
       )}

--- a/src/app/features/room/message/styles.css.ts
+++ b/src/app/features/room/message/styles.css.ts
@@ -70,13 +70,3 @@ export const SendStatusRow = style({
   gap: config.space.S200,
   marginTop: config.space.S100,
 });
-
-export const SendStatusButton = style([
-  DefaultReset,
-  {
-    color: 'inherit',
-    cursor: 'pointer',
-    textDecoration: 'underline',
-    fontSize: toRem(12),
-  },
-]);


### PR DESCRIPTION
Replaces plain text/icon buttons on failed message state with Chip components for retry and delete actions, consistent with the design system.