### PR TITLE
feat(settings): badge count DMs-only toggle and highlight-only app badge option

### DIFF
--- a/.changeset/badge_count_dms_only_setting.md
+++ b/.changeset/badge_count_dms_only_setting.md
@@ -1,0 +1,5 @@
+---
+sable: minor
+---
+
+Added a "Badge Counts for DMs Only" setting: when enabled, unread count numbers only appear on Direct Message room badges; non-DM rooms and spaces show a plain dot instead of a number, even when Show Unread Counts is on.

--- a/src/app/components/unread-badge/UnreadBadge.tsx
+++ b/src/app/components/unread-badge/UnreadBadge.tsx
@@ -7,6 +7,8 @@ import { settingsAtom } from '$state/settings';
 type UnreadBadgeProps = {
   highlight?: boolean;
   count: number;
+  /** Whether this badge belongs to a DM room. Used with the badgeCountDMsOnly setting. */
+  dm?: boolean;
 };
 const styles: CSSProperties = {
   minWidth: toRem(16),
@@ -19,11 +21,14 @@ export function UnreadBadgeCenter({ children }: { children: ReactNode }) {
   );
 }
 
-export function UnreadBadge({ highlight, count }: UnreadBadgeProps) {
+export function UnreadBadge({ highlight, count, dm }: UnreadBadgeProps) {
   const [showUnreadCounts] = useSetting(settingsAtom, 'showUnreadCounts');
+  const [badgeCountDMsOnly] = useSetting(settingsAtom, 'badgeCountDMsOnly');
   const [showPingCounts] = useSetting(settingsAtom, 'showPingCounts');
 
-  const showNumber = count > 0 && (showUnreadCounts || (highlight && showPingCounts));
+  // Show count when: (showUnreadCounts OR highlight+showPingCounts) AND (not DM-only mode OR this is a DM)
+  const showNumber =
+    count > 0 && (showUnreadCounts || (highlight && showPingCounts)) && (!badgeCountDMsOnly || dm);
 
   return (
     <Badge

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -424,7 +424,11 @@ export function RoomNavItem({
               )}
               {!optionsVisible && (unread || hasRoomUnread) && (
                 <UnreadBadgeCenter>
-                  <UnreadBadge highlight={!!unread && unread.highlight > 0} count={unreadCount} />
+                  <UnreadBadge
+                    highlight={!!unread && unread.highlight > 0}
+                    count={unreadCount}
+                    dm={direct}
+                  />
                 </UnreadBadgeCenter>
               )}
               {!optionsVisible && notificationMode !== RoomNotificationMode.Unset && (

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -328,6 +328,7 @@ function PageZoomInput() {
 export function Appearance() {
   const [twitterEmoji, setTwitterEmoji] = useSetting(settingsAtom, 'twitterEmoji');
   const [showUnreadCounts, setShowUnreadCounts] = useSetting(settingsAtom, 'showUnreadCounts');
+  const [badgeCountDMsOnly, setBadgeCountDMsOnly] = useSetting(settingsAtom, 'badgeCountDMsOnly');
   const [showPingCounts, setShowPingCounts] = useSetting(settingsAtom, 'showPingCounts');
 
   return (
@@ -354,6 +355,15 @@ export function Appearance() {
             description="Display the number of unread messages on room and sidebar badges."
             after={
               <Switch variant="Primary" value={showUnreadCounts} onChange={setShowUnreadCounts} />
+            }
+          />
+        </SequenceCard>
+        <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+          <SettingTile
+            title="Badge Counts for DMs Only"
+            description="Only show unread counts on Direct Message badges. Non-DM rooms and spaces show a plain dot instead."
+            after={
+              <Switch variant="Primary" value={badgeCountDMsOnly} onChange={setBadgeCountDMsOnly} />
             }
           />
         </SequenceCard>

--- a/src/app/pages/client/sidebar/DirectTab.tsx
+++ b/src/app/pages/client/sidebar/DirectTab.tsx
@@ -111,6 +111,7 @@ export function DirectTab() {
           <UnreadBadge
             highlight={directUnread.highlight > 0}
             count={directUnread.highlight > 0 ? directUnread.highlight : directUnread.total}
+            dm
           />
         </SidebarItemBadge>
       )}

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -72,6 +72,7 @@ export interface Settings {
   hideMembershipInReadOnly: boolean;
   useRightBubbles: boolean;
   showUnreadCounts: boolean;
+  badgeCountDMsOnly: boolean;
   showPingCounts: boolean;
 }
 
@@ -129,6 +130,7 @@ const defaultSettings: Settings = {
   hideMembershipInReadOnly: true,
   useRightBubbles: false,
   showUnreadCounts: true,
+  badgeCountDMsOnly: false,
   showPingCounts: true,
 };
 


### PR DESCRIPTION
Adds two new badge settings: badgeCountDMsOnly (only show unread counts on DM badges; non-DM rooms get a plain dot) and integrates with the existing showPingCounts setting. Moves the Show Unread Counts tile from Cosmetics to Themes alongside the new toggle.