### PR TITLE
fix(media): remove allowRedirects, add error fallbacks, apply useAuthentication in html parser

### DIFF
--- a/.changeset/media_auth_error_fallback.md
+++ b/.changeset/media_auth_error_fallback.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Fixed media authentication handling: removed unnecessary redirect following, added error fallback UI for failed media loads, and ensured authentication headers are applied consistently when rendering inline media in HTML message bodies.

--- a/src/app/components/message/Reaction.tsx
+++ b/src/app/components/message/Reaction.tsx
@@ -1,4 +1,5 @@
-import { Box, Text, as } from 'folds';
+import { useState } from 'react';
+import { Box, Icon, Icons, Text, as } from 'folds';
 import classNames from 'classnames';
 import { MatrixClient, MatrixEvent, Room } from '$types/matrix-sdk';
 import { getHexcodeForEmoji, getShortcodeFor } from '$plugins/emoji';
@@ -16,34 +17,52 @@ export const Reaction = as<
     reaction: string;
     useAuthentication?: boolean;
   }
->(({ className, mx, count, reaction, useAuthentication, ...props }, ref) => (
-  <Box
-    as="button"
-    className={classNames(css.Reaction, className)}
-    alignItems="Center"
-    shrink="No"
-    gap="200"
-    {...props}
-    ref={ref}
-  >
-    <Text className={css.ReactionText} as="span" size="T400">
-      {reaction.startsWith('mxc://') ? (
-        <img
-          className={css.ReactionImg}
-          src={mxcUrlToHttp(mx, reaction, useAuthentication) ?? reaction}
-          alt={reaction}
-        />
-      ) : (
-        <Text as="span" size="Inherit" truncate>
-          {reaction}
-        </Text>
-      )}
-    </Text>
-    <Text as="span" size="T300">
-      {count}
-    </Text>
-  </Box>
-));
+>(({ className, mx, count, reaction, useAuthentication, ...props }, ref) => {
+  const [imgError, setImgError] = useState(false);
+
+  return (
+    <Box
+      as="button"
+      className={classNames(css.Reaction, className)}
+      alignItems="Center"
+      shrink="No"
+      gap="200"
+      {...props}
+      ref={ref}
+    >
+      <Text className={css.ReactionText} as="span" size="T400">
+        {reaction.startsWith('mxc://') ? (
+          (() => {
+            if (imgError)
+              return (
+                // Image loaded but fetch failed — show a small warning icon so the
+                // reaction button still renders correctly and the user can see
+                // something went wrong rather than a browser broken-image icon.
+                <span title="Failed to load emoji image" aria-label="Failed to load emoji image">
+                  <Icon size="100" src={Icons.Warning} style={{ opacity: 0.5 }} />
+                </span>
+              );
+            return (
+              <img
+                className={css.ReactionImg}
+                src={mxcUrlToHttp(mx, reaction, useAuthentication) ?? reaction}
+                alt={reaction}
+                onError={() => setImgError(true)}
+              />
+            );
+          })()
+        ) : (
+          <Text as="span" size="Inherit" truncate>
+            {reaction}
+          </Text>
+        )}
+      </Text>
+      <Text as="span" size="T300">
+        {count}
+      </Text>
+    </Box>
+  );
+});
 
 type ReactionTooltipMsgProps = {
   room: Room;

--- a/src/app/plugins/react-custom-html-parser.tsx
+++ b/src/app/plugins/react-custom-html-parser.tsx
@@ -3,6 +3,7 @@ import {
   ComponentPropsWithoutRef,
   lazy,
   ReactEventHandler,
+  ReactNode,
   Suspense,
   useMemo,
   useState,
@@ -316,6 +317,20 @@ export function CodeBlock({
   );
 }
 
+/**
+ * Thin wrapper around <img> that gracefully swaps in a fallback node when the
+ * image fails to load (e.g. federation down, mxc URL unavailable).  Avoids the
+ * silent browser broken-image icon showing up in message bodies.
+ */
+function FallbackImg({
+  fallback,
+  ...props
+}: ComponentPropsWithoutRef<'img'> & { fallback: ReactNode }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) return <>{fallback}</>;
+  return <img {...props} onError={() => setFailed(true)} />;
+}
+
 export const getReactCustomHtmlParser = (
   mx: MatrixClient,
   roomId: string | undefined,
@@ -501,8 +516,15 @@ export const getReactCustomHtmlParser = (
         }
 
         if (name === 'img') {
+          // Guard: img without a src survives sanitisation (fix for crash #1731)
+          // but we can't convert it — skip rendering rather than passing
+          // undefined into mxcUrlToHttp where it would throw.
+          if (!props.src) return null;
+
           const htmlSrc = mxcUrlToHttp(mx, props.src, params.useAuthentication) ?? undefined;
 
+          // Non-mxc images were already converted to <a> links by the sanitiser,
+          // but handle the edge case defensively here too.
           if (htmlSrc && !props.src.startsWith('mxc://')) {
             return (
               <a href={htmlSrc} target="_blank" rel="noreferrer noopener">
@@ -511,7 +533,18 @@ export const getReactCustomHtmlParser = (
             );
           }
 
-          if (htmlSrc && 'data-mx-emoticon' in props) {
+          if ('data-mx-emoticon' in props) {
+            // When the mxc URL can't be resolved (e.g. federation unavailable),
+            // fall back to rendering the shortcode text so the message stays readable.
+            if (!htmlSrc) {
+              const label = props.alt || props.title || '';
+              return (
+                <span title={label} className={css.EmoticonBase}>
+                  {label ? `:${label}:` : ''}
+                </span>
+              );
+            }
+
             const siblingCount = domNode.parent?.children.length ?? 0;
 
             // seperate style for bundled emojis
@@ -519,11 +552,19 @@ export const getReactCustomHtmlParser = (
               return (
                 <span className={css.EmoticonBase}>
                   <span className={css.Emoticon()}>
-                    <img
+                    <FallbackImg
                       {...props}
                       src={htmlSrc}
                       className={css.EmoticonImg}
                       style={{ verticalAlign: 'middle' }}
+                      fallback={
+                        <span
+                          title={`Failed to load: ${props.alt || props.title || ''}`}
+                          className={css.EmoticonBase}
+                        >
+                          {props.alt || props.title ? `:${props.alt || props.title}:` : '?'}
+                        </span>
+                      }
                     />
                   </span>
                 </span>
@@ -534,13 +575,37 @@ export const getReactCustomHtmlParser = (
             return (
               <span className={css.EmoticonBase}>
                 <span className={css.Emoticon()}>
-                  <img {...props} src={htmlSrc} className={css.EmoticonImg} />
+                  <FallbackImg
+                    {...props}
+                    src={htmlSrc}
+                    className={css.EmoticonImg}
+                    fallback={
+                      <span
+                        title={`Failed to load: ${props.alt || props.title || ''}`}
+                        className={css.EmoticonBase}
+                      >
+                        {props.alt || props.title ? `:${props.alt || props.title}:` : '?'}
+                      </span>
+                    }
+                  />
                 </span>
               </span>
             );
           }
 
-          if (htmlSrc) return <img {...props} className={css.Img} src={htmlSrc} />;
+          if (htmlSrc)
+            return (
+              <FallbackImg
+                {...props}
+                className={css.Img}
+                src={htmlSrc}
+                fallback={
+                  <span title={`Failed to load media${props.alt ? `: ${props.alt}` : ''}`}>
+                    {props.alt || '[media]'}
+                  </span>
+                }
+              />
+            );
         }
       }
 

--- a/src/app/utils/matrix.ts
+++ b/src/app/utils/matrix.ts
@@ -293,8 +293,7 @@ export const mxcUrlToHttp = (
   width?: number,
   height?: number,
   resizeMethod?: string,
-  allowDirectLinks?: boolean,
-  allowRedirects?: boolean
+  allowDirectLinks?: boolean
 ): string | null =>
   mx.mxcUrlToHttp(
     mxcUrl.replace(/^["']|["']$/g, ''),
@@ -302,7 +301,7 @@ export const mxcUrlToHttp = (
     height,
     resizeMethod,
     allowDirectLinks,
-    allowRedirects,
+    undefined,
     useAuthentication
   );
 


### PR DESCRIPTION
Removes the allowRedirects option from media requests (no longer needed), adds proper error fallback rendering for failed media loads, and ensures useAuthentication is applied consistently in the custom HTML parser for inline media.