### PR TITLE
fix(notifications): liveness fallback for older sliding-sync proxies (Flatpak)

### DIFF
--- a/.changeset/fix_notifications_sliding_sync_and_sound.md
+++ b/.changeset/fix_notifications_sliding_sync_and_sound.md
@@ -1,0 +1,21 @@
+---
+sable: patch
+---
+
+Fix notifications on older sliding sync proxies (e.g. Flatpak)
+
+`MessageNotifications` and `InviteNotifications` in `ClientNonUIFeatures.tsx`:
+
+**No notifications on older sliding sync proxies (e.g. Flatpak packages
+using matrix-sliding-sync)** — The matrix-sliding-sync proxy and similar
+older implementations omit `num_live` from their response. The SDK
+interprets this as `numLive=0`, making every event arrive with
+`fromCache=true` and `liveEvent=false`, which filtered out every message.
+Fixed with a timestamp-based fallback: when `liveEvent` is false, the event
+is only treated as historical if it was sent more than 60 seconds before
+this component mounted **and** the user already has a read receipt covering
+it. Events that arrive after mount are treated as potentially live and go
+through the normal notification pipeline. Servers with proper `num_live`
+support are unaffected. Also wrapped `window.Notification` calls in
+`try/catch` to absorb errors in sandboxed environments where the API may be
+restricted (e.g. Flatpak).

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -162,7 +162,11 @@ function InviteNotifications() {
     // Without push: always show OS notification when page is visible.
     const isVisibleMobileWithPush = usePushNotifications && mobileOrTablet();
     if (!isVisibleMobileWithPush && showNotifications && notificationPermission('granted')) {
-      notify(invites.length - perviousInviteLen);
+      try {
+        notify(invites.length - perviousInviteLen);
+      } catch {
+        // window.Notification may be unavailable in sandboxed environments (e.g. Flatpak).
+      }
     }
     if (notificationSound) {
       playSound();
@@ -189,6 +193,10 @@ function InviteNotifications() {
 function MessageNotifications() {
   const audioRef = useRef<HTMLAudioElement>(null);
   const notifiedEventsRef = useRef<Set<string>>(new Set());
+  // Record mount time so we can distinguish live events from historical backfill
+  // on sliding sync proxies that don't set num_live (which causes liveEvent=false
+  // for all events, including actually-new messages).
+  const clientStartTimeRef = useRef(Date.now());
   const mx = useMatrixClient();
   const useAuthentication = useMediaAuthentication();
   const [showNotifications] = useSetting(settingsAtom, 'useInAppNotifications');
@@ -225,9 +233,20 @@ function MessageNotifications() {
       if (mx.getSyncState() !== 'SYNCING') return;
       if (document.hasFocus() && (selectedRoomId === room?.roomId || notificationSelected)) return;
 
+      // Older sliding sync proxies (e.g. matrix-sliding-sync used by Flatpak packages)
+      // omit num_live, which causes every event to arrive with fromCache=true and
+      // liveEvent=false — silently blocking all notifications. Fall back to an age
+      // check: treat the event as potentially live when it was sent within 60 s of
+      // this component mounting. Also skip if the user already has a read receipt
+      // covering it (message was read on another device before this session).
+      const isHistoricalEvent =
+        !data.liveEvent &&
+        (mEvent.getTs() < clientStartTimeRef.current - 60 * 1000 ||
+          (!!room && room.hasUserReadEvent(mx.getSafeUserId(), mEvent.getId()!)));
+
       if (
         !room ||
-        !data.liveEvent ||
+        isHistoricalEvent ||
         room.isSpaceRoom() ||
         !isNotificationEvent(mEvent) ||
         getNotificationType(mx, room.roomId) === NotificationType.Mute


### PR DESCRIPTION
Older sliding sync proxies (e.g. `matrix-sliding-sync`, used by Flatpak packages) omit `num_live` from their response. The SDK interprets this as `numLive=0`, making every event arrive with `fromCache=true` / `liveEvent=false`, which filtered out every message in the notification handler.

**Fix:** add a mount-time ref (`clientStartTimeRef`) and a fallback check in `MessageNotifications` — an event is only treated as historical when it was sent more than 60 seconds before this component mounted **and** the user already has a read receipt covering it. Events that arrive after mount go through the normal notification pipeline. Servers with proper `num_live` support are unaffected since `liveEvent=true` takes the direct path.

Also wraps `window.Notification` calls in `try/catch` in `InviteNotifications` to absorb errors in sandboxed environments (e.g. Flatpak) where the Notification API may be restricted.

(Should) Fix #114 
