### PR TITLE
fix(notifications): rich banner body + fix encrypted message dedup

### DIFF
--- a/.changeset/notification_banner_rich_body.md
+++ b/.changeset/notification_banner_rich_body.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Fixed in-app notification banners in encrypted rooms showing "Encrypted Message" instead of the actual content. Banners now also render rich text (mentions, inline images) using the same pipeline as the timeline renderer.

--- a/src/app/components/notification-banner/NotificationBanner.css.ts
+++ b/src/app/components/notification-banner/NotificationBanner.css.ts
@@ -110,10 +110,17 @@ export const BannerRoomName = style({
 });
 
 // Caps tall previews and fades the bottom edge when content overflows.
+// Desktop: 25vh, mobile (≤768px): 35vh.
 export const BannerBody = style({
   position: 'relative',
-  maxHeight: toRem(56),
+  maxHeight: '25vh',
   overflow: 'hidden',
+
+  '@media': {
+    '(max-width: 768px)': {
+      maxHeight: '35vh',
+    },
+  },
 
   selectors: {
     '&[data-overflow=true]::after': {

--- a/src/app/components/notification-banner/NotificationBanner.tsx
+++ b/src/app/components/notification-banner/NotificationBanner.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from 'jotai';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Icon, IconButton, Icons, Text } from 'folds';
 import { inAppBannerAtom, InAppBannerNotification } from '$state/sessions';
 import * as css from './NotificationBanner.css';
@@ -21,6 +21,26 @@ function BodyText({ text, hovered }: { text: string; hovered: boolean }) {
     <div ref={ref} className={css.BannerBody} data-overflow={overflow} data-hovered={hovered}>
       <Text size="T200" priority="300">
         {text}
+      </Text>
+    </div>
+  );
+}
+
+// Same as BodyText but renders a pre-built ReactNode (rich HTML with mxc/mention transforms).
+function BodyNode({ node, hovered }: { node: ReactNode; hovered: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [overflow, setOverflow] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    setOverflow(el.scrollHeight > el.clientHeight);
+  }, [node]);
+
+  return (
+    <div ref={ref} className={css.BannerBody} data-overflow={overflow} data-hovered={hovered}>
+      <Text size="T200" priority="300">
+        {node}
       </Text>
     </div>
   );
@@ -115,7 +135,11 @@ function BannerItem({ notification, onDismiss }: BannerItemProps) {
             </span>
           )}
         </Text>
-        {notification.body && <BodyText text={notification.body} hovered={paused} />}
+        {notification.bodyNode ? (
+          <BodyNode node={notification.bodyNode} hovered={paused} />
+        ) : (
+          notification.body && <BodyText text={notification.body} hovered={paused} />
+        )}
       </div>
       <Box shrink="No">
         <IconButton

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -2,6 +2,9 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { ReactNode, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { PushProcessor, RoomEvent, RoomEventHandlerMap } from '$types/matrix-sdk';
+import parse from 'html-react-parser';
+import { getReactCustomHtmlParser, LINKIFY_OPTS } from '$plugins/react-custom-html-parser';
+import { sanitizeCustomHtml } from '$utils/sanitize';
 import { roomToUnreadAtom } from '$state/room/roomToUnread';
 import LogoSVG from '$public/res/svg/cinny.svg';
 import { NotificationBanner } from '$components/notification-banner';
@@ -251,6 +254,13 @@ function MessageNotifications() {
         (mEvent.getTs() < clientStartTimeRef.current - 60 * 1000 ||
           (!!room && room.hasUserReadEvent(mx.getSafeUserId(), mEvent.getId()!)));
 
+      // m.room.encrypted events haven't been decrypted yet; the SDK will
+      // re-emit the event after decryption with the real type and content.
+      // Without this guard we'd add the eventId to notifiedEventsRef here,
+      // causing the decrypted re-emission to be deduped — showing
+      // "Encrypted Message" instead of the actual content.
+      if (mEvent.getType() === 'm.room.encrypted') return;
+
       if (
         !room ||
         isHistoricalEvent ||
@@ -300,6 +310,7 @@ function MessageNotifications() {
           getMemberDisplayName(room, sender, nicknamesRef.current) ??
           getMxIdLocalPart(sender) ??
           sender;
+        const content = mEvent.getContent();
         const previewText = resolveNotificationPreviewText({
           content: mEvent.getContent(),
           eventType: mEvent.getType(),
@@ -307,6 +318,25 @@ function MessageNotifications() {
           showMessageContent,
           showEncryptedMessageContent,
         });
+
+        // Build a rich ReactNode body using the same HTML parser as the room
+        // timeline — this gives full mxc image transforms, mention pills,
+        // linkify, spoilers, code blocks, etc.
+        let bodyNode: ReactNode;
+        if (
+          showMessageContent &&
+          (!isEncryptedRoom || showEncryptedMessageContent) &&
+          content.format === 'org.matrix.custom.html' &&
+          content.formatted_body
+        ) {
+          const htmlParserOpts = getReactCustomHtmlParser(mx, room.roomId, {
+            linkifyOpts: LINKIFY_OPTS,
+            useAuthentication,
+            nicknames: nicknamesRef.current,
+          });
+          bodyNode = parse(sanitizeCustomHtml(content.formatted_body), htmlParserOpts) as ReactNode;
+        }
+
         const payload = buildRoomMessageNotification({
           roomName: room.name ?? 'Unknown',
           roomAvatar,
@@ -327,6 +357,7 @@ function MessageNotifications() {
           serverName,
           senderName: resolvedSenderName,
           body: previewText,
+          bodyNode,
           icon: roomAvatar,
           onClick: () => {
             window.focus();

--- a/src/app/state/sessions.ts
+++ b/src/app/state/sessions.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { atom } from 'jotai';
 import { createLogger } from '$utils/debug';
 import {
@@ -185,6 +186,11 @@ export type InAppBannerNotification = {
   /** Display name of the sender. */
   senderName?: string;
   body?: string;
+  /**
+   * Pre-rendered rich body with mxc/mention transforms (built in ClientNonUIFeatures).
+   * When present, takes precedence over the plain-text `body` fallback.
+   */
+  bodyNode?: ReactNode;
   /** URL of an avatar or room icon to display inside the banner. */
   icon?: string;
   onClick: () => void;


### PR DESCRIPTION
## Problem

In-app notification banners in encrypted rooms always showed **"Encrypted Message"** instead of actual content. This should now be resolved.

Additionally, the banner body was plain text only, truncating formatting, mentions, and inline images even in unencrypted rooms, this has been rectified (though in testing, images don't always render - but they do show an image file was received)
