### PR TITLE
Add support for audio and video previews in URL previews and reuse attachment components

### DIFF
--- a/src/app/components/url-preview/UrlPreview.tsx
+++ b/src/app/components/url-preview/UrlPreview.tsx
@@ -7,13 +7,10 @@ export const UrlPreview = as<'div'>(({ className, ...props }, ref) => (
   <Box shrink="No" className={classNames(css.UrlPreview, className)} {...props} ref={ref} />
 ));
 
-export const UrlPreviewImg = as<'img'>(({ className, alt, ...props }, ref) => (
-  <img className={classNames(css.UrlPreviewImg, className)} alt={alt} {...props} ref={ref} />
-));
-
 export const UrlPreviewContent = as<'div'>(({ className, ...props }, ref) => (
   <Box
     grow="Yes"
+    shrink="No"
     direction="Column"
     gap="100"
     className={classNames(css.UrlPreviewContent, className)}

--- a/src/app/components/url-preview/UrlPreviewCard.css.tsx
+++ b/src/app/components/url-preview/UrlPreviewCard.css.tsx
@@ -1,5 +1,14 @@
+import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
-import { DefaultReset, color, toRem } from 'folds';
+import { DefaultReset, color, config, toRem } from 'folds';
+
+export const UrlPreviewAudio = style([
+  DefaultReset,
+  {
+    padding: config.space.S300,
+    paddingTop: 0,
+  },
+]);
 
 export const UrlPreviewHolderGradient = recipe({
   base: [

--- a/src/app/components/url-preview/UrlPreviewCard.tsx
+++ b/src/app/components/url-preview/UrlPreviewCard.tsx
@@ -3,7 +3,7 @@ import { IPreviewUrlResponse } from 'matrix-js-sdk';
 import { Box, Icon, IconButton, Icons, Scroll, Spinner, Text, as, color, config } from 'folds';
 import { AsyncStatus, useAsyncCallback } from '../../hooks/useAsyncCallback';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
-import { UrlPreview, UrlPreviewContent, UrlPreviewDescription, UrlPreviewImg } from './UrlPreview';
+import { UrlPreview, UrlPreviewContent, UrlPreviewDescription } from './UrlPreview';
 import {
   getIntersectionObserverEntry,
   useIntersectionObserver,
@@ -12,6 +12,9 @@ import * as css from './UrlPreviewCard.css';
 import { tryDecodeURIComponent } from '../../utils/dom';
 import { mxcUrlToHttp } from '../../utils/matrix';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
+import { AudioContent, ImageContent, VideoContent } from '../message';
+import { Image, MediaControl, Video } from '../media';
+import { ImageViewer } from '../image-viewer';
 
 const linkStyles = { color: color.Success.Main };
 
@@ -41,8 +44,44 @@ export const UrlPreviewCard = as<'div', { url: string; ts: number }>(
       );
 
       return (
-        <>
-          {imgUrl && <UrlPreviewImg src={imgUrl} alt={prev['og:title']} title={prev['og:title']} />}
+        <Box grow="Yes" direction="ColumnReverse" gap="0">
+          {(prev['og:video'] && (
+            <VideoContent
+              style={{
+                aspectRatio:
+                  ((prev['og:video:width'] as number) ?? 1) /
+                  ((prev['og:video:height'] as number) ?? 1),
+              }}
+              body={prev['og:title']}
+              info={{}}
+              url={prev['og:video'] as string}
+              mimeType={(prev['og:video:type'] as string) ?? ''}
+              renderVideo={(vidProps) => <Video style={{ objectFit: 'contain' }} {...vidProps} />}
+              renderThumbnail={() => <Image src={imgUrl ?? undefined} />}
+            />
+          )) ||
+            (prev['og:image'] && (
+              <ImageContent
+                style={{
+                  aspectRatio: (prev['og:image:width'] ?? 1) / (prev['og:image:height'] ?? 1),
+                }}
+                autoPlay
+                body={prev['og:title']}
+                url={prev['og:image']}
+                renderViewer={(p) => <ImageViewer {...p} />}
+                renderImage={(p) => <Image style={{ objectFit: 'contain' }} {...p} />}
+              />
+            )) ||
+            (prev['og:audio'] && (
+              <Box className={css.UrlPreviewAudio}>
+                <AudioContent
+                  url={(prev['og:audio'] as string) ?? ''}
+                  mimeType={(prev['og:audio:type'] as string) ?? ''}
+                  info={{}}
+                  renderMediaControl={(p) => <MediaControl {...p} />}
+                />
+              </Box>
+            ))}
           <UrlPreviewContent>
             <Text
               style={linkStyles}
@@ -64,7 +103,7 @@ export const UrlPreviewCard = as<'div', { url: string; ts: number }>(
               <UrlPreviewDescription>{prev['og:description']}</UrlPreviewDescription>
             </Text>
           </UrlPreviewContent>
-        </>
+        </Box>
       );
     };
 


### PR DESCRIPTION
### Description
This PR adds support for audio and video previews, which are currently unspecified by the Matrix protocol, and tweaks the URL preview component to reuse the attachment media components. I frequently used audio and video URL previews in Discord and felt this functionality was very lacking in Matrix.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
