### PR TITLE
fix: source version string and build hash from build system

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,6 +85,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VITE_BUILD_HASH=${{ steps.vars.outputs.short_sha }}
+            VITE_IS_RELEASE_TAG=${{ steps.release_tag.outputs.is_release }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM --platform=$BUILDPLATFORM node:24.13.1-alpine AS builder
 WORKDIR /src
 
 ARG VITE_BUILD_HASH
+ARG VITE_IS_RELEASE_TAG=false
 ENV VITE_BUILD_HASH=$VITE_BUILD_HASH
+ENV VITE_IS_RELEASE_TAG=$VITE_IS_RELEASE_TAG
 
 COPY .npmrc package.json package-lock.json /src/
 RUN npm ci --ignore-scripts

--- a/src/app/features/settings/about/About.tsx
+++ b/src/app/features/settings/about/About.tsx
@@ -147,6 +147,7 @@ type AboutProps = {
 };
 export function About({ requestClose }: AboutProps) {
   const mx = useMatrixClient();
+  const devLabel = IS_RELEASE_TAG ? '' : '-dev';
   const buildLabel = BUILD_HASH ? ` (${BUILD_HASH})` : '';
 
   return (
@@ -181,7 +182,7 @@ export function About({ requestClose }: AboutProps) {
                   <Box direction="Column" gap="100">
                     <Box gap="100" alignItems="End">
                       <Text size="H3">Sable</Text>
-                      <Text size="T200">{`v${APP_VERSION}${buildLabel}`}</Text>
+                      <Text size="T200">{`v${APP_VERSION}${devLabel}${buildLabel}`}</Text>
                     </Box>
                     <Text>Yet another matrix client fork(ed from cinny).</Text>
                   </Box>

--- a/src/app/pages/auth/AuthFooter.tsx
+++ b/src/app/pages/auth/AuthFooter.tsx
@@ -14,7 +14,7 @@ export function AuthFooter() {
         target="_blank"
         rel="noreferrer"
       >
-        v{APP_VERSION}
+        {`v${APP_VERSION}${IS_RELEASE_TAG ? '' : `-dev${BUILD_HASH ? ` (${BUILD_HASH})` : ''}`}`}
       </Text>
       <Text as="a" size="T300" href="https://matrix.org" target="_blank" rel="noreferrer">
         Powered by Matrix

--- a/src/app/pages/auth/AuthFooter.tsx
+++ b/src/app/pages/auth/AuthFooter.tsx
@@ -14,7 +14,7 @@ export function AuthFooter() {
         target="_blank"
         rel="noreferrer"
       >
-        v1.4.0
+        v{APP_VERSION}
       </Text>
       <Text as="a" size="T300" href="https://matrix.org" target="_blank" rel="noreferrer">
         Powered by Matrix

--- a/src/app/pages/client/WelcomePage.tsx
+++ b/src/app/pages/client/WelcomePage.tsx
@@ -19,7 +19,7 @@ export function WelcomePage() {
               <span>
                 Yet another matrix client fork.{' '}
                 <a href="https://github.com/7w1/sable" target="_blank" rel="noreferrer noopener">
-                  v1.4.0
+                  v{APP_VERSION}
                 </a>
               </span>
             }

--- a/src/app/pages/client/WelcomePage.tsx
+++ b/src/app/pages/client/WelcomePage.tsx
@@ -19,7 +19,7 @@ export function WelcomePage() {
               <span>
                 Yet another matrix client fork.{' '}
                 <a href="https://github.com/7w1/sable" target="_blank" rel="noreferrer noopener">
-                  v{APP_VERSION}
+                  {`v${APP_VERSION}${IS_RELEASE_TAG ? '' : `-dev${BUILD_HASH ? ` (${BUILD_HASH})` : ''}`}`}
                 </a>
               </span>
             }

--- a/src/ext.d.ts
+++ b/src/ext.d.ts
@@ -2,6 +2,7 @@
 
 declare const APP_VERSION: string;
 declare const BUILD_HASH: string;
+declare const IS_RELEASE_TAG: boolean;
 
 declare module 'browser-encrypt-attachment' {
   export interface EncryptedAttachmentInfo {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,6 +46,17 @@ const resolveBuildHash = (): string | undefined => {
 const appVersion = packageJson.version;
 const buildHash = resolveBuildHash();
 
+const isReleaseTag = (() => {
+  const envVal = process.env.VITE_IS_RELEASE_TAG;
+  if (envVal !== undefined && envVal !== '') return envVal === 'true';
+  try {
+    const tag = execSync('git describe --exact-match --tags HEAD 2>/dev/null').toString().trim();
+    return tag.startsWith('sable/v');
+  } catch {
+    return false;
+  }
+})();
+
 const copyFiles = {
   targets: [
     {
@@ -112,6 +123,7 @@ export default defineConfig({
   define: {
     APP_VERSION: JSON.stringify(appVersion),
     BUILD_HASH: JSON.stringify(buildHash ?? ''),
+    IS_RELEASE_TAG: JSON.stringify(isReleaseTag),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
### Description

- Replace hardcoded `v1.4.0` version strings in [AuthFooter.tsx](cci:7://file:///Users/dporter/dev/src/github.com/ArgoIV/sable/src/app/pages/auth/AuthFooter.tsx:0:0-0:0) and [WelcomePage.tsx](cci:7://file:///Users/dporter/dev/src/github.com/ArgoIV/sable/src/app/pages/client/WelcomePage.tsx:0:0-0:0) with the `APP_VERSION` constant (already sourced from `package.json` via Vite), ensuring the version is defined in a single place.
- Add `IS_RELEASE_TAG` build-time constant to distinguish release vs. development builds. Non-release builds display `vX.Y.Z-dev (hash)` across the auth footer, welcome page, and about page.
- `IS_RELEASE_TAG` is resolved via `git describe` locally, or via the `VITE_IS_RELEASE_TAG` build arg in Docker/CI.
- Update [Dockerfile](cci:7://file:///Users/dporter/dev/src/github.com/ArgoIV/sable/Dockerfile:0:0-0:0) and CI workflow ([docker-publish.yml](cci:7://file:///Users/dporter/dev/src/github.com/ArgoIV/sable/.github/workflows/docker-publish.yml:0:0-0:0)) to pass `VITE_BUILD_HASH` and `VITE_IS_RELEASE_TAG` as build args, since `.git` is not available inside the Docker build context.

Example screenshot showing the dev docker build at the HEAD of this PR:
<img width="571" height="291" alt="Screenshot 2026-03-06 at 14 58 00" src="https://github.com/user-attachments/assets/c1380f83-b5f1-43f6-bcfb-8a4858aed6dd" />


#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings