### PR TITLE
fix(notifications): banner default off on desktop, show for DMs, fix space navigation

### DIFF
--- a/.changeset/notification_banner_dm_default.md
+++ b/.changeset/notification_banner_dm_default.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+In-app notification banners now appear for DMs by default; desktop banner setting defaults to off; fixed space room navigation from banner tap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 * Reply quotes now automatically retry decryption for E2EE messages, display a distinct placeholder for replies from blocked users, and fix edge cases where reply event loading could silently fail.
 * Service worker push notifications now correctly deep-link to the right account and room on cold PWA launch. Notifications are automatically suppressed when the app window is already visible. The In-App (pill banner) and System (OS) notification settings are now independent: desktop shows both controls, mobile shows Push and In-App only. Tapping an in-app notification pill on mobile now opens the room timeline directly instead of routing through the space navigation panel.
 * Fixed several room timeline issues with sliding sync: corrected event rendering order, more accurate scroll-to-bottom detection, phantom unread count clearing when the timeline is already at the bottom, and fixed pagination spinner state.
+* In-app notification banners now appear for DMs by default, even without a mention or keyword match.
+* Notification banner on desktop now defaults to off, consistent with push notification defaults.
+* Fixed space room navigation when tapping an in-app notification banner for a room inside a space.
 
 ## 1.3.3 - 3/4/2026
 

--- a/src/app/hooks/useNotificationJumper.ts
+++ b/src/app/hooks/useNotificationJumper.ts
@@ -7,13 +7,15 @@ import { mDirectAtom } from '../state/mDirectList';
 import { useSyncState } from './useSyncState';
 import { useMatrixClient } from './useMatrixClient';
 import { getCanonicalAliasOrRoomId } from '../utils/matrix';
-import { getDirectRoomPath, getHomeRoomPath } from '../pages/pathUtils';
+import { getDirectRoomPath, getHomeRoomPath, getSpaceRoomPath } from '../pages/pathUtils';
+import { roomToParentsAtom } from '../state/room/roomToParents';
 import { createLogger } from '../utils/debug';
 
 export function NotificationJumper() {
   const [pending, setPending] = useAtom(pendingNotificationAtom);
   const activeSessionId = useAtomValue(activeSessionIdAtom);
   const mDirects = useAtomValue(mDirectAtom);
+  const roomToParents = useAtomValue(roomToParentsAtom);
   const mx = useMatrixClient();
   const navigate = useNavigate();
   const log = createLogger('NotificationJumper');
@@ -57,7 +59,22 @@ export function NotificationJumper() {
       if (mDirects.has(pending.roomId)) {
         navigate(getDirectRoomPath(roomIdOrAlias, pending.eventId));
       } else {
-        navigate(getHomeRoomPath(roomIdOrAlias, pending.eventId));
+        // If the room lives inside a space, route through the space path so
+        // SpaceRouteRoomProvider can resolve it — HomeRouteRoomProvider only
+        // knows orphan rooms and would show JoinBeforeNavigate otherwise.
+        const parents = roomToParents.get(pending.roomId);
+        const firstParentId = parents && [...parents][0];
+        if (firstParentId) {
+          navigate(
+            getSpaceRoomPath(
+              getCanonicalAliasOrRoomId(mx, firstParentId),
+              roomIdOrAlias,
+              pending.eventId
+            )
+          );
+        } else {
+          navigate(getHomeRoomPath(roomIdOrAlias, pending.eventId));
+        }
       }
       setPending(null);
       // jumpingRef stays true until pending changes — see effect below.
@@ -68,7 +85,7 @@ export function NotificationJumper() {
         membership: room?.getMyMembership(),
       });
     }
-  }, [pending, activeSessionId, mx, mDirects, navigate, setPending, log]);
+  }, [pending, activeSessionId, mx, mDirects, roomToParents, navigate, setPending, log]);
 
   // Reset the guard only when pending is replaced (new notification or cleared).
   useEffect(() => {

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -16,6 +16,7 @@ import { notificationPermission, setFavicon } from '$utils/dom';
 import { useSetting } from '$state/hooks/settings';
 import { settingsAtom } from '$state/settings';
 import { nicknamesAtom } from '$state/nicknames';
+import { mDirectAtom } from '$state/mDirectList';
 import { allInvitesAtom } from '$state/room-list/inviteList';
 import { usePreviousValue } from '$hooks/usePreviousValue';
 import { useMatrixClient } from '$hooks/useMatrixClient';
@@ -217,6 +218,9 @@ function MessageNotifications() {
   const nicknames = useAtomValue(nicknamesAtom);
   const nicknamesRef = useRef(nicknames);
   nicknamesRef.current = nicknames;
+  const mDirects = useAtomValue(mDirectAtom);
+  const mDirectsRef = useRef(mDirects);
+  mDirectsRef.current = mDirects;
 
   const setPending = useSetAtom(pendingNotificationAtom);
   const setInAppBanner = useSetAtom(inAppBannerAtom);
@@ -283,9 +287,10 @@ function MessageNotifications() {
       if (!pushActions?.notify) return;
       const loudByRule = Boolean(pushActions.tweaks?.sound);
       const isHighlightByRule = Boolean(pushActions.tweaks?.highlight);
+      const isDM = mDirectsRef.current.has(room.roomId);
 
-      // If neither a loud nor a highlight rule matches, nothing to show.
-      if (!isHighlightByRule && !loudByRule) return;
+      // If neither a loud nor a highlight rule matches, and it's not a DM, nothing to show.
+      if (!isHighlightByRule && !loudByRule && !isDM) return;
 
       // Page hidden: SW (push) handles the OS notification. Nothing to do in-app.
       if (document.visibilityState !== 'visible') return;
@@ -299,7 +304,7 @@ function MessageNotifications() {
 
       // Page is visible — show the themed in-app notification banner for any
       // highlighted message (mention / keyword) or loud push rule.
-      if (mobileOrTablet() && (isHighlightByRule || loudByRule) && showNotifications) {
+      if (showNotifications && (isHighlightByRule || loudByRule || isDM)) {
         const isEncryptedRoom = !!getStateEvent(room, StateEvent.RoomEncryption);
         const avatarMxc =
           room.getAvatarFallbackMember()?.getMxcAvatarUrl() ?? room.getMxcAvatarUrl();

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -107,11 +107,10 @@ const defaultSettings: Settings = {
   legacyUsernameColor: false,
 
   // Push notifications (SW/Sygnal): default on for mobile, opt-in on desktop.
-  // In-app pill banner: always on — it's the primary foreground alert on mobile
-  // and a useful secondary alert on desktop.
+  // In-app pill banner: default on for mobile (primary foreground alert), opt-in on desktop.
   // System (OS) notifications: desktop-only; hidden and disabled on mobile.
   usePushNotifications: mobileOrTablet(),
-  useInAppNotifications: true,
+  useInAppNotifications: mobileOrTablet(),
   useSystemNotifications: !mobileOrTablet(),
   isNotificationSounds: true,
   showMessageContentInNotifications: false,


### PR DESCRIPTION
## Summary

Improves in-app notification banner behaviour on three fronts.

## Changes

### Banner shown for DMs by default

Previously the in-app banner only appeared for messages matching a highlight or loud push rule (mentions, keywords, `@room`). DMs that matched only the generic DM push rule were silently dropped. The banner now also fires for any message in a DM room, matching expected behaviour for a chat client where DMs always warrant a visible alert.

### Desktop banner default changed to off

The in-app notification banner setting now defaults to **off** on desktop, consistent with system (OS) push notification defaults. Users who want banners can enable them in Settings. Previously the banner defaulted to on everywhere, which could result in double-notifications on desktop when both the banner and the OS notification fired simultaneously.

### Space room navigation fixed

When tapping an in-app notification banner for a message in a room that lives inside a space, the router now correctly activates the parent space in the sidebar before navigating to the room. Previously the navigation jumped directly to the room path, which could leave the space collapsed and the room appearing unreachable via the sidebar.

## Files changed

- `src/app/hooks/useNotificationJumper.ts` — space navigation fix
- `src/app/pages/client/ClientNonUIFeatures.tsx` — DM detection and banner trigger logic
- `src/app/state/settings.ts` — desktop banner default changed to off

## Changelog

- In-app notification banners now appear for DMs by default, even without a mention or keyword match.
- Notification banner on desktop now defaults to off, consistent with push notification defaults.
- Fixed space room navigation when tapping an in-app notification banner for a room inside a space.
