### PR TITLE
fix(timeline): prefer room-scoped member avatar over global profile

### DIFF
--- a/.changeset/member_avatar_room_scope.md
+++ b/.changeset/member_avatar_room_scope.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Timeline message avatars now use the room-specific avatar and display name instead of the user's global profile, when set via `/myroomavatar` or `/myroomnick`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@
 * Reply quotes now automatically retry decryption for E2EE messages, display a distinct placeholder for replies from blocked users, and fix edge cases where reply event loading could silently fail.
 * Service worker push notifications now correctly deep-link to the right account and room on cold PWA launch. Notifications are automatically suppressed when the app window is already visible. The In-App (pill banner) and System (OS) notification settings are now independent: desktop shows both controls, mobile shows Push and In-App only. Tapping an in-app notification pill on mobile now opens the room timeline directly instead of routing through the space navigation panel.
 * Fixed several room timeline issues with sliding sync: corrected event rendering order, more accurate scroll-to-bottom detection, phantom unread count clearing when the timeline is already at the bottom, and fixed pagination spinner state.
-* Timeline message avatars now use the room-specific avatar and display name instead of the user's global profile when set via `/myroomavatar` or `/myroomnick`.
 
 ## 1.3.3 - 3/4/2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Reply quotes now automatically retry decryption for E2EE messages, display a distinct placeholder for replies from blocked users, and fix edge cases where reply event loading could silently fail.
 * Service worker push notifications now correctly deep-link to the right account and room on cold PWA launch. Notifications are automatically suppressed when the app window is already visible. The In-App (pill banner) and System (OS) notification settings are now independent: desktop shows both controls, mobile shows Push and In-App only. Tapping an in-app notification pill on mobile now opens the room timeline directly instead of routing through the space navigation panel.
 * Fixed several room timeline issues with sliding sync: corrected event rendering order, more accurate scroll-to-bottom detection, phantom unread count clearing when the timeline is already at the bottom, and fixed pagination spinner state.
+* Timeline message avatars now use the room-specific avatar and display name instead of the user's global profile when set via `/myroomavatar` or `/myroomnick`.
 
 ## 1.3.3 - 3/4/2026
 

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -341,9 +341,11 @@ function MessageInternal(
   const { color: usernameColor, font: usernameFont } = useSableCosmetics(senderId, room);
 
   // Avatars
+  // Prefer the room-scoped member avatar (m.room.member) over the global profile
+  // avatar so per-room avatar overrides are respected in the timeline.
   const avatarUrl = useMemo(() => {
     if (collapse) return undefined;
-    const mxc = profile.avatarUrl || getMemberAvatarMxc(room, senderId);
+    const mxc = getMemberAvatarMxc(room, senderId) || profile.avatarUrl;
     return mxc ? mxcUrlToHttp(mx, mxc, useAuthentication, 48, 48, 'crop') : undefined;
   }, [collapse, profile.avatarUrl, senderId, mx, room, useAuthentication]);
 


### PR DESCRIPTION
## Summary

Fixes timeline message avatars to prefer room-specific profile data over the user's global profile when a room-specific avatar or display name has been set.

## Background

Matrix supports per-room member profiles: a user can set a different display name and avatar for each room via `/myroomnick` and `/myroomavatar`. Previously, `Message.tsx` resolved the sender's avatar using only the global profile, ignoring any room-member-scoped overrides. This meant custom room avatars set by users (commonly used in pseudonymous communities) were never shown in the message timeline.

## Changes

- `src/app/features/room/message/Message.tsx` — avatar resolution now reads from the `RoomMember` object (room-scoped state) first and falls back to the global profile only when no room-scoped avatar is set.

This matches the Matrix spec behaviour and is consistent with how display names are already resolved elsewhere in the timeline.

## Changelog

- Timeline message avatars now use the room-specific avatar and display name instead of the user's global profile when set via `/myroomavatar` or `/myroomnick`.
