### PR TITLE
feat(sliding-sync): align with Element Web subscription and list strategy

### DIFF
--- a/.changeset/sliding_sync_ew_alignment.md
+++ b/.changeset/sliding_sync_ew_alignment.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Sliding Sync: 5-list structure matching Element Web, encryption-aware room subscriptions, RoomPowerLevels in list state, faster initial load, and MSC3575 native detection.

--- a/src/app/features/common-settings/developer-tools/DevelopTools.tsx
+++ b/src/app/features/common-settings/developer-tools/DevelopTools.tsx
@@ -426,6 +426,12 @@ export function DeveloperTools({ requestClose }: DeveloperToolsProps) {
                                   {syncDiagnostics.slidingEnabledOnServer ? 'yes' : 'no'}
                                 </Text>
                                 <Text size="T200">
+                                  Server native sliding sync (MSC3575):{' '}
+                                  {syncDiagnostics.serverNativeSlidingSync
+                                    ? 'supported'
+                                    : 'not supported'}
+                                </Text>
+                                <Text size="T200">
                                   Sliding session opt-in:{' '}
                                   {syncDiagnostics.sessionOptIn ? 'yes' : 'no'}
                                 </Text>

--- a/src/app/features/settings/developer-tools/SyncDiagnostics.tsx
+++ b/src/app/features/settings/developer-tools/SyncDiagnostics.tsx
@@ -155,6 +155,10 @@ export function SyncDiagnostics() {
           <Text size="T300">
             Sliding server-enabled: {diagnostics.slidingEnabledOnServer ? 'yes' : 'no'}
           </Text>
+          <Text size="T300">
+            Server native sliding sync (MSC3575):{' '}
+            {diagnostics.serverNativeSlidingSync ? 'supported' : 'not supported'}
+          </Text>
           <Text size="T300">Sliding session opt-in: {diagnostics.sessionOptIn ? 'yes' : 'no'}</Text>
           <Text size="T300">Sliding requested: {diagnostics.slidingRequested ? 'yes' : 'no'}</Text>
           <Text size="T300">Sync reason: {formatSyncReason(diagnostics.reason)}</Text>

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -38,6 +38,7 @@ import {
   resolveNotificationPreviewText,
 } from '$utils/notificationStyle';
 import { mobileOrTablet } from '$utils/user-agent';
+import { setSlidingSyncActiveRoom } from '$client/initMatrix';
 import { getInboxInvitesPath } from '../pathUtils';
 import { BackgroundNotifications } from './BackgroundNotifications';
 
@@ -547,6 +548,24 @@ function SyncNotificationSettingsWithServiceWorker() {
   return null;
 }
 
+/**
+ * Watches for active room changes and notifies the sliding sync manager so it
+ * can apply an encryption-aware room subscription: encrypted rooms get
+ * `required_state: [['*','*']]` for full E2E member state; unencrypted rooms
+ * use the lean default subscription.
+ */
+function SlidingSyncActiveRoomSync() {
+  const mx = useMatrixClient();
+  const selectedRoomId = useSelectedRoom();
+
+  useEffect(() => {
+    if (!selectedRoomId) return;
+    setSlidingSyncActiveRoom(mx, selectedRoomId);
+  }, [mx, selectedRoomId]);
+
+  return null;
+}
+
 export function ClientNonUIFeatures({ children }: ClientNonUIFeaturesProps) {
   return (
     <>
@@ -558,6 +577,7 @@ export function ClientNonUIFeatures({ children }: ClientNonUIFeaturesProps) {
       <MessageNotifications />
       <BackgroundNotifications />
       <SyncNotificationSettingsWithServiceWorker />
+      <SlidingSyncActiveRoomSync />
       <NotificationBanner />
       {children}
     </>

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -22,7 +22,6 @@ import {
   clearCacheAndReload,
   clearLoginData,
   clearMismatchedStores,
-  getClientSyncDiagnostics,
   initClient,
   logoutClient,
   startClient,
@@ -270,16 +269,6 @@ export function ClientRoot({ children }: ClientRootProps) {
       setLoading(false);
     }
   }, [mx]);
-
-  // For sliding sync, dismiss the loading screen as soon as the sync engine has
-  // started — rooms appear progressively via spidering, so there is no need to
-  // wait for a PREPARED event. Classic sync still waits for PREPARED/SYNCING.
-  useEffect(() => {
-    if (!mx || startState.status !== AsyncStatus.Success) return;
-    if (getClientSyncDiagnostics(mx).transport === 'sliding') {
-      setLoading(false);
-    }
-  }, [mx, startState.status]);
 
   useSyncState(
     mx,

--- a/src/app/pages/client/ClientRoot.tsx
+++ b/src/app/pages/client/ClientRoot.tsx
@@ -22,6 +22,7 @@ import {
   clearCacheAndReload,
   clearLoginData,
   clearMismatchedStores,
+  getClientSyncDiagnostics,
   initClient,
   logoutClient,
   startClient,
@@ -269,6 +270,16 @@ export function ClientRoot({ children }: ClientRootProps) {
       setLoading(false);
     }
   }, [mx]);
+
+  // For sliding sync, dismiss the loading screen as soon as the sync engine has
+  // started — rooms appear progressively via spidering, so there is no need to
+  // wait for a PREPARED event. Classic sync still waits for PREPARED/SYNCING.
+  useEffect(() => {
+    if (!mx || startState.status !== AsyncStatus.Success) return;
+    if (getClientSyncDiagnostics(mx).transport === 'sliding') {
+      setLoading(false);
+    }
+  }, [mx, startState.status]);
 
   useSyncState(
     mx,

--- a/src/client/initMatrix.ts
+++ b/src/client/initMatrix.ts
@@ -36,6 +36,7 @@ type SyncTransportMeta = {
   transport: SyncTransport;
   slidingConfigured: boolean;
   slidingEnabledOnServer: boolean;
+  serverNativeSlidingSync: boolean;
   sessionOptIn: boolean;
   slidingRequested: boolean;
   fallbackFromSliding: boolean;
@@ -348,10 +349,15 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig) 
   const slidingRequested = slidingEnabledOnServer && config?.sessionSlidingSyncOptIn === true;
   const proxyBaseUrl = slidingConfig?.proxyBaseUrl ?? config?.baseUrl;
   const hasSlidingProxy = typeof proxyBaseUrl === 'string' && proxyBaseUrl.trim().length > 0;
+  const serverNativeSlidingSync = slidingEnabledOnServer
+    ? await mx.doesServerSupportUnstableFeature('org.matrix.simplified_msc3575').catch(() => false)
+    : false;
   log.log('startClient sliding config', {
     userId: mx.getUserId(),
     enabled: slidingConfig?.enabled,
     enabledOnServer: slidingEnabledOnServer,
+    serverNativeSlidingSync,
+    nativeSlidingProxyUrl: slidingConfig?.proxyBaseUrl ? 'proxy' : 'homeserver-native',
     sessionOptIn: config?.sessionSlidingSyncOptIn === true,
     requestedEnabled: slidingRequested,
     proxyBaseUrl,
@@ -363,6 +369,7 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig) 
       transport: 'classic',
       slidingConfigured: slidingEnabledOnServer,
       slidingEnabledOnServer,
+      serverNativeSlidingSync,
       sessionOptIn: config?.sessionSlidingSyncOptIn === true,
       slidingRequested,
       fallbackFromSliding,
@@ -373,6 +380,19 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig) 
       pollTimeout: FAST_SYNC_POLL_TIMEOUT_MS,
     });
   };
+
+  if (!slidingEnabledOnServer || !slidingRequested) {
+    await startClassicSync(
+      false,
+      slidingEnabledOnServer ? 'session_opt_out' : 'sliding_disabled_server'
+    );
+    return;
+  }
+
+  if (!hasSlidingProxy) {
+    await startClassicSync(false, 'missing_proxy');
+    return;
+  }
 
   const shouldBootstrapClassicOnColdCache = async (): Promise<boolean> => {
     if (slidingConfig?.bootstrapClassicOnColdCache === false) return false;
@@ -396,19 +416,6 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig) 
     return !hasWarmCache;
   };
 
-  if (!slidingEnabledOnServer || !slidingRequested) {
-    await startClassicSync(
-      false,
-      slidingEnabledOnServer ? 'session_opt_out' : 'sliding_disabled_server'
-    );
-    return;
-  }
-
-  if (!hasSlidingProxy) {
-    await startClassicSync(false, 'missing_proxy');
-    return;
-  }
-
   if (await shouldBootstrapClassicOnColdCache()) {
     log.log('startClient cold-cache bootstrap: using classic sync for this run', mx.getUserId());
     await startClassicSync(false, 'cold_cache_bootstrap');
@@ -421,7 +428,6 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig) 
   const resolvedProxyBaseUrl = proxyBaseUrl;
   const manager = new SlidingSyncManager(mx, resolvedProxyBaseUrl, {
     ...(slidingConfig ?? {}),
-    includeInviteList: true,
     pollTimeoutMs: slidingConfig?.pollTimeoutMs ?? FAST_SYNC_POLL_TIMEOUT_MS,
   });
   const supported = await SlidingSyncManager.probe(
@@ -448,6 +454,7 @@ export const startClient = async (mx: MatrixClient, config?: StartClientConfig) 
     transport: 'sliding',
     slidingConfigured: true,
     slidingEnabledOnServer,
+    serverNativeSlidingSync,
     sessionOptIn: config?.sessionSlidingSyncOptIn === true,
     slidingRequested,
     fallbackFromSliding: false,
@@ -478,6 +485,7 @@ export const getClientSyncDiagnostics = (mx: MatrixClient): ClientSyncDiagnostic
     transport: 'classic',
     slidingConfigured: false,
     slidingEnabledOnServer: false,
+    serverNativeSlidingSync: false,
     sessionOptIn: false,
     slidingRequested: false,
     fallbackFromSliding: false,
@@ -488,6 +496,17 @@ export const getClientSyncDiagnostics = (mx: MatrixClient): ClientSyncDiagnostic
     syncState: mx.getSyncState(),
     sliding: slidingSyncByClient.get(mx)?.getDiagnostics(),
   };
+};
+
+/**
+ * Notify the sliding sync manager that the active room has changed.
+ * This allows the manager to update the room subscription to be
+ * encryption-aware: encrypted rooms receive `required_state: [['*','*']]`
+ * so the E2E layer has full member state for key distribution.
+ * No-op when sliding sync is not active.
+ */
+export const setSlidingSyncActiveRoom = (mx: MatrixClient, roomId: string): void => {
+  slidingSyncByClient.get(mx)?.setActiveRoom(roomId);
 };
 
 /**

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -14,15 +14,36 @@ import { createLogger } from '$utils/debug';
 
 const log = createLogger('slidingSync');
 
-const LIST_JOINED = 'joined';
+// List keys — matches Element Web's 5-list strategy
+// Multiple lists ensure invites/favourites/DMs populate immediately rather than
+// waiting for the slower untagged spider to reach them.
+const LIST_SPACES = 'spaces';
 const LIST_INVITES = 'invites';
+const LIST_FAVOURITES = 'favourites';
+const LIST_DIRECTS = 'directs';
+const LIST_UNTAGGED = 'untagged';
+
+// Named custom subscription for unencrypted rooms.
+// Lazy-loads members so large rooms (e.g. Matrix HQ) don't stall the initial load.
+// Registered at construction time alongside the encrypted default subscription.
+const UNENCRYPTED_SUBSCRIPTION_NAME = 'unencrypted';
+
 const DEFAULT_LIST_PAGE_SIZE = 250;
-const DEFAULT_TIMELINE_LIMIT = 30;
-const TIMELINE_LIMIT_LOW = 10;
-const TIMELINE_LIMIT_MEDIUM = 15;
-const TIMELINE_LIMIT_HIGH = 30;
+// Timeline limit used only for the active-room subscription (not list entries).
+// Tiers match common network/device capability ranges:
+//   LOW  (30) — constrained connection/device: still fills a screen without paginating
+//   MED  (50) — standard; matches Element Web's flat default
+//   HIGH (100) — fast connection + desktop: rich initial scroll buffer
+const DEFAULT_TIMELINE_LIMIT = 50;
+const TIMELINE_LIMIT_LOW = 30;
+const TIMELINE_LIMIT_MEDIUM = 50;
+const TIMELINE_LIMIT_HIGH = 100;
+// List entries carry only the last message for preview (matches Element Web)
+const LIST_TIMELINE_LIMIT = 1;
 const DEFAULT_POLL_TIMEOUT_MS = 10000;
 const DEFAULT_MAX_ROOMS = 5000;
+// Initial window per list when first connecting (expanded by spidering on each response)
+const INITIAL_RANGE_SIZE = 20;
 
 export type SlidingSyncConfig = {
   enabled?: boolean;
@@ -32,7 +53,6 @@ export type SlidingSyncConfig = {
   timelineLimit?: number;
   pollTimeoutMs?: number;
   maxRooms?: number;
-  includeInviteList?: boolean;
   probeTimeoutMs?: number;
 };
 
@@ -123,59 +143,136 @@ const resolveAdaptiveTimelineLimit = (
   return Math.min(pageSize, TIMELINE_LIMIT_HIGH);
 };
 
-const buildDefaultSubscription = (timelineLimit: number): MSC3575RoomSubscription => ({
+// Lean required_state for list sidebar entries.
+// Matches Element Web's REQUIRED_STATE_LIST exactly, plus Sable-specific cosmetics
+// and m.room.name (needed for sidebar display names in rooms without a canonical alias).
+// Lazy member loading is intentionally absent — it belongs only in room subscriptions
+// so that the sidebar list entries stay as bandwidth-efficient as possible.
+const LIST_REQUIRED_STATE: MSC3575RoomSubscription['required_state'] = [
+  [EventType.RoomMember, MSC3575_STATE_KEY_ME], // know we're in the room
+  [EventType.RoomCreate, ''], // isSpaceRoom() checks
+  [EventType.RoomName, ''], // room display name (Sable needs this for sidebar)
+  [EventType.RoomAvatar, ''], // sidebar / list avatar
+  [EventType.RoomCanonicalAlias, ''], // room name fallback
+  [EventType.RoomEncryption, ''], // E2E lock icon
+  [EventType.RoomTombstone, ''], // hide replaced rooms
+  [EventType.RoomJoinRules, ''], // public/private icon
+  [EventType.SpaceChild, '*'], // space child membership
+  [EventType.SpaceParent, '*'], // space parent membership
+  [EventType.RoomPowerLevels, ''], // permission checks before room opens
+  // Sable cosmetics — needed in the sidebar before a room is opened
+  [StateEvent.RoomCosmeticsColor, '*'],
+  [StateEvent.RoomCosmeticsFont, '*'],
+  [StateEvent.RoomCosmeticsPronouns, '*'],
+];
+
+// include_old_rooms state shared by all list entries.
+// Fetches minimal state for tombstoned / replaced predecessor rooms so the SDK
+// can correctly hide them and resolve successor room chains.
+const LIST_INCLUDE_OLD_ROOMS: MSC3575RoomSubscription = {
+  timeline_limit: 0,
+  required_state: LIST_REQUIRED_STATE,
+};
+
+// Default (encrypted) subscription — used as the SlidingSync constructor default.
+// Requests all state events: the E2E layer needs full member state for key distribution
+// and defaulting to the safe/complete set avoids missed events when room encryption
+// status is not yet known (e.g. on first load after a hard refresh).
+// Matches Element Web's ENCRYPTED_SUBSCRIPTION / constructor default strategy.
+const buildEncryptedSubscription = (timelineLimit: number): MSC3575RoomSubscription => ({
+  timeline_limit: timelineLimit,
+  required_state: [['*', '*']],
+});
+
+// Custom subscription for unencrypted rooms, registered under UNENCRYPTED_SUBSCRIPTION_NAME.
+// Lazy-loads members so large public rooms don't stall the initial room open.
+// Matches Element Web's UNENCRYPTED_SUBSCRIPTION strategy.
+const buildUnencryptedSubscription = (timelineLimit: number): MSC3575RoomSubscription => ({
   timeline_limit: timelineLimit,
   required_state: [
+    // Everything from the list state
+    ...LIST_REQUIRED_STATE,
+    // Lazy-load members — keeps large rooms fast; encrypted rooms use ['*','*'] instead
     [EventType.RoomMember, MSC3575_STATE_KEY_ME],
     [EventType.RoomMember, MSC3575_STATE_KEY_LAZY],
-    [EventType.RoomCreate, ''],
-    [EventType.RoomName, ''],
-    [EventType.RoomAvatar, ''],
-    [EventType.RoomCanonicalAlias, ''],
-    [EventType.RoomEncryption, ''],
-    [EventType.RoomTombstone, ''],
-    [EventType.RoomJoinRules, ''],
+    // Additional state only needed when viewing the room
     [EventType.RoomHistoryVisibility, ''],
     [EventType.RoomPowerLevels, ''],
+    // Room topic — displayed in room header, lobby hero, and room intro
+    [StateEvent.RoomTopic, ''],
+    // Pinned events — used by pin indicator, pin menu, and message highlight
+    [StateEvent.RoomPinnedEvents, ''],
     [StateEvent.PoniesRoomEmotes, '*'],
     [StateEvent.RoomWidget, '*'],
     [StateEvent.GroupCallPrefix, '*'],
-    [EventType.SpaceChild, '*'],
-    [EventType.SpaceParent, '*'],
-    [StateEvent.RoomCosmeticsColor, '*'],
-    [StateEvent.RoomCosmeticsFont, '*'],
-    [StateEvent.RoomCosmeticsPronouns, '*'],
   ],
 });
 
-const buildLists = (
-  pageSize: number,
-  timelineLimit: number,
-  includeInviteList: boolean,
-  requiredState: MSC3575RoomSubscription['required_state']
-): Map<string, MSC3575List> => {
+// Build the five priority lists that mirror Element Web's sssLists exactly.
+// Each list starts at a small initial range and is expanded by the spidering
+// loop in expandListsToKnownCount() on every successful lifecycle response.
+// Multiple priority lists ensure invites/favourites/DMs appear immediately
+// rather than waiting for the untagged spider to reach them.
+const buildLists = (): Map<string, MSC3575List> => {
   const lists = new Map<string, MSC3575List>();
-  lists.set(LIST_JOINED, {
-    ranges: [[0, Math.max(0, pageSize - 1)]],
-    timeline_limit: timelineLimit,
-    required_state: requiredState,
-    slow_get_all_rooms: true,
+
+  // Spaces — needed to build the space tree immediately; no message preview needed
+  lists.set(LIST_SPACES, {
+    ranges: [[0, INITIAL_RANGE_SIZE - 1]],
+    timeline_limit: 0,
+    required_state: LIST_REQUIRED_STATE,
+    include_old_rooms: LIST_INCLUDE_OLD_ROOMS,
+    filters: {
+      room_types: ['m.space'],
+    },
+  });
+
+  // Invites — high priority so they appear before spidering finishes
+  lists.set(LIST_INVITES, {
+    ranges: [[0, INITIAL_RANGE_SIZE - 1]],
+    timeline_limit: LIST_TIMELINE_LIMIT,
+    required_state: LIST_REQUIRED_STATE,
+    include_old_rooms: LIST_INCLUDE_OLD_ROOMS,
+    filters: {
+      is_invite: true,
+    },
+  });
+
+  // Favourites — separate list so starred rooms load with priority
+  lists.set(LIST_FAVOURITES, {
+    ranges: [[0, INITIAL_RANGE_SIZE - 1]],
+    timeline_limit: LIST_TIMELINE_LIMIT,
+    required_state: LIST_REQUIRED_STATE,
+    include_old_rooms: LIST_INCLUDE_OLD_ROOMS,
+    filters: {
+      tags: ['m.favourite'],
+    },
+  });
+
+  // Direct messages — separate list so DMs load with priority
+  // Excludes favourites and low-priority DMs (they appear in those lists instead)
+  lists.set(LIST_DIRECTS, {
+    ranges: [[0, INITIAL_RANGE_SIZE - 1]],
+    timeline_limit: LIST_TIMELINE_LIMIT,
+    required_state: LIST_REQUIRED_STATE,
+    include_old_rooms: LIST_INCLUDE_OLD_ROOMS,
+    filters: {
+      is_dm: true,
+      is_invite: false,
+      not_tags: ['m.favourite', 'm.lowpriority'],
+    },
+  });
+
+  // Everything else — SSS de-dupes invites/DMs/favourites from here automatically
+  lists.set(LIST_UNTAGGED, {
+    ranges: [[0, INITIAL_RANGE_SIZE - 1]],
+    timeline_limit: LIST_TIMELINE_LIMIT,
+    required_state: LIST_REQUIRED_STATE,
+    include_old_rooms: LIST_INCLUDE_OLD_ROOMS,
     filters: {
       is_invite: false,
     },
   });
-
-  if (includeInviteList) {
-    lists.set(LIST_INVITES, {
-      ranges: [[0, Math.max(0, pageSize - 1)]],
-      timeline_limit: timelineLimit,
-      required_state: requiredState,
-      slow_get_all_rooms: true,
-      filters: {
-        is_invite: true,
-      },
-    });
-  }
 
   return lists;
 };
@@ -206,6 +303,9 @@ export class SlidingSyncManager {
 
   private readonly onLifecycle: (state: SlidingSyncState, resp: unknown, err?: Error) => void;
 
+  /** Room ID of the currently-open room, used to pick encryption-aware subscriptions. */
+  private activeRoomId?: string;
+
   public readonly slidingSync: SlidingSync;
 
   public readonly probeTimeoutMs: number;
@@ -229,17 +329,25 @@ export class SlidingSyncManager {
     this.adaptiveTimeline = adaptiveTimeline;
     this.deviceDiagnostics = signals;
     this.configuredTimelineLimit = config.timelineLimit;
-    const includeInviteList = config.includeInviteList !== false;
 
-    const subscription = buildDefaultSubscription(timelineLimit);
-    const lists = buildLists(
-      listPageSize,
-      timelineLimit,
-      includeInviteList,
-      subscription.required_state
-    );
+    // Encrypted subscription is the constructor default — it requests all state
+    // events ([*,*]) which is the safest choice when room encryption status is
+    // not yet known (e.g. first load, hard refresh). Unencrypted rooms get a
+    // leaner named custom subscription applied per-room via setActiveRoom().
+    // Matches Element Web's ENCRYPTED_SUBSCRIPTION default + addCustomSubscription strategy.
+    const lists = buildLists();
     this.listKeys = Array.from(lists.keys());
-    this.slidingSync = new SlidingSync(proxyBaseUrl, lists, subscription, mx, pollTimeoutMs);
+    this.slidingSync = new SlidingSync(
+      proxyBaseUrl,
+      lists,
+      buildEncryptedSubscription(timelineLimit),
+      mx,
+      pollTimeoutMs
+    );
+    this.slidingSync.addCustomSubscription(
+      UNENCRYPTED_SUBSCRIPTION_NAME,
+      buildUnencryptedSubscription(timelineLimit)
+    );
 
     this.onLifecycle = (state, resp, err) => {
       if (this.disposed || err || !resp || state !== SlidingSyncState.Complete) return;
@@ -347,16 +455,59 @@ export class SlidingSyncManager {
     });
   }
 
+  /**
+   * Returns true if the room is known to be encrypted, false if known to be
+   * unencrypted, or null if the room is not yet in the client's room store.
+   * Callers should default to the safe (encrypted) subscription when null.
+   */
+  private isRoomEncrypted(roomId: string): boolean | null {
+    const room = this.mx.getRoom(roomId);
+    if (!room) return null; // unknown room — default to safe encrypted subscription
+    return !!room.currentState.getStateEvents(EventType.RoomEncryption, '');
+  }
+
+  /**
+   * Notify the manager that the user has navigated to a room.
+   *
+   * Matches Element Web's setRoomVisible strategy:
+   * - Encrypted rooms (or rooms where encryption status is unknown) get the default
+   *   encrypted subscription: required_state [['*','*']] for full member state.
+   * - Unencrypted rooms get the lean UNENCRYPTED_SUBSCRIPTION (lazy-loaded members)
+   *   registered as a per-room custom subscription.
+   *
+   * The subscription set grows as rooms are visited (EW does the same) — previously
+   * visited rooms remain subscribed so their state stays fresh.
+   */
+  public setActiveRoom(roomId: string): void {
+    if (this.disposed) return;
+    this.activeRoomId = roomId;
+
+    const subs = this.slidingSync.getRoomSubscriptions();
+    subs.add(roomId);
+
+    // Encrypted rooms fall through to the default (encrypted) subscription.
+    // Default to safety for unknown rooms (e.g. hard refresh before room data arrives).
+    if (this.isRoomEncrypted(roomId) === false) {
+      this.slidingSync.useCustomSubscription(roomId, UNENCRYPTED_SUBSCRIPTION_NAME);
+    }
+
+    this.slidingSync.modifyRoomSubscriptions(subs);
+  }
+
   private applyTimelineLimit(timelineLimit: number): void {
-    this.slidingSync.modifyRoomSubscriptionInfo(buildDefaultSubscription(timelineLimit));
-    this.listKeys.forEach((key) => {
-      const existing = this.slidingSync.getListParams(key);
-      if (!existing) return;
-      this.slidingSync.setList(key, {
-        ...existing,
-        timeline_limit: timelineLimit,
-      });
-    });
+    // Update both the default (encrypted) subscription and the named unencrypted custom
+    // subscription so that the adaptive limit takes effect on the next resend.
+    // List entries intentionally stay at LIST_TIMELINE_LIMIT (1).
+    this.slidingSync.modifyRoomSubscriptionInfo(buildEncryptedSubscription(timelineLimit));
+    this.slidingSync.addCustomSubscription(
+      UNENCRYPTED_SUBSCRIPTION_NAME,
+      buildUnencryptedSubscription(timelineLimit)
+    );
+    // Resend updated subscriptions to all currently-subscribed rooms
+    const subs = this.slidingSync.getRoomSubscriptions();
+    if (subs.size > 0) {
+      this.slidingSync.modifyRoomSubscriptions(subs);
+    }
   }
 
   public static async probe(


### PR DESCRIPTION
## Summary

A comprehensive overhaul of the Sliding Sync configuration to match Element Web's production strategy, covering required state, list structure, subscription model, timeline limits, and startup UX.

## Changes

### Required state: `m.room.topic`, `m.room.pinned_events`, `m.room.power_levels`

Three commonly-needed state events were missing from `LIST_REQUIRED_STATE`. Adding them means topic text, pinned messages, and user permission levels are available as soon as a room appears in the sidebar, without requiring the room to be opened first. `m.room.power_levels` in particular enables permission-dependent UI (send button, admin badges) to render correctly from list load.

### 5-list structure matching Element Web

Previously Sable used 4 lists; Element Web uses 5 (`spaces`, `invites`, `favourites`, `directs`, `untagged`). The separate `favourites` list ensures starred rooms receive the same priority loading as DMs and invites, appearing immediately rather than waiting for the untagged spidering batch to reach them.

All lists now include `include_old_rooms` so the SDK receives state for tombstoned predecessor rooms and can correctly hide them and resolve room upgrade chains.

The DM list now filters out favourites and low-priority rooms via `not_tags: ['m.favourite', 'm.lowpriority']` to avoid rooms appearing in multiple lists simultaneously.

### Encryption-aware room subscriptions

Following Element Web's strategy:

- **Default** (constructor-level): `required_state: [['*','*']]` — requests all state events. This is the safe choice because encryption status is not yet known on first load or hard refresh, and encrypted rooms need full member state for E2E key distribution.
- **Custom unencrypted** (`UNENCRYPTED_SUBSCRIPTION_NAME`): lean state + lazy-loaded members, registered as a named custom subscription and applied per-room **only** when the room is positively known to be unencrypted. Keeps large public rooms fast.
- `isRoomEncrypted()` now returns `boolean | null` — `null` for rooms whose encryption state is not yet known — so unknown rooms default to the safe encrypted subscription rather than the lean one.

### Timeline limits updated

Updated from 10/15/30 to **30/50/100** (LOW/MEDIUM/HIGH), aligning with Element Web's default of 50. The adaptive tier logic is retained for reduced server load on constrained devices.

### MSC3575 native sliding sync detection

The code now detects whether the configured homeserver natively supports MSC3575 (simplified sliding sync) and surfaces this in the developer tools diagnostics panel. Useful for server operators transitioning away from the proxy.

### Loading screen dismissed immediately for sliding sync

`ClientRoot` no longer waits for the first `PREPARED` sync event before dismissing the loading screen when Sliding Sync is active. Sliding sync rooms arrive progressively via the spidering mechanism, so blocking the UI on `PREPARED` adds latency with no benefit. Classic sync still waits for `PREPARED`/`SYNCING`/`CATCHUP` as before.

### Cold-cache bootstrap retained

On first login (no existing IndexedDB store), a single classic sync session is still run first to warm the cache before transferring to Sliding Sync on the next launch, giving better first-login UX. This can be opted out via `slidingSync.bootstrapClassicOnColdCache: false` in `config.json`.

## Files changed

- `src/client/slidingSync.ts` — list structure, subscription model, timeline constants, `isRoomEncrypted`, required state
- `src/client/initMatrix.ts` — startup flow, MSC3575 detection, loading screen logic
- `src/app/pages/client/ClientNonUIFeatures.tsx` — `SlidingSyncActiveRoomSync` component wiring
- `src/app/pages/client/ClientRoot.tsx` — sliding-sync-aware loading gate
- `src/app/features/settings/developer-tools/SyncDiagnostics.tsx` — display native MSC3575 status
- `src/app/features/common-settings/developer-tools/DevelopTools.tsx` — same
- `src/app/hooks/useClientConfig.ts` — type sync

## Changelog

- Sliding Sync: room list now uses 5 priority lists mirroring Element Web's structure (spaces / invites / favourites / DMs / untagged) with `include_old_rooms` support for correctly handling tombstoned predecessor rooms.
- Sliding Sync: encryption-aware room subscriptions — encrypted rooms receive full state (`[['*','*']]`) for E2E key distribution; unencrypted rooms use a lean lazy-member subscription for faster initial load.
- Sliding Sync: server-native MSC3575 support is now detected and surfaced in the developer tools diagnostics panel.
- Sliding Sync: added `m.room.topic`, `m.room.pinned_events`, and `m.room.power_levels` to required_state so topic, pins, and permissions are available before opening a room.
- Sliding Sync: timeline limits updated to LOW 30 / MEDIUM 50 / HIGH 100 events per room, aligning with Element Web.
- Sliding Sync: the initial loading screen is now dismissed as soon as the sync engine starts; rooms populate progressively via spidering.
