### PR TITLE
fix: Element Call DM video calls + delayed event methods + post-lobby reload

### DIFF
--- a/.changeset/element-call-dm-video-calls.md
+++ b/.changeset/element-call-dm-video-calls.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Fix Element Call video/audio calls in DM and non-voice rooms: after joining through the lobby, the in-call grid now displays correctly instead of showing only the control bar.

--- a/src/app/features/call/SmallWidget.ts
+++ b/src/app/features/call/SmallWidget.ts
@@ -15,6 +15,7 @@ import {
   MatrixClient,
   MatrixEvent,
   MatrixEventEvent,
+  Room,
   RoomStateEvent,
 } from '$types/matrix-sdk';
 import {
@@ -32,6 +33,25 @@ import { CinnyWidget } from './CinnyWidget';
 import { SmallWidgetDriver } from './SmallWidgetDriver';
 
 const log = createLogger('SmallWidget');
+
+/**
+ * Returns the appropriate EC `intent` and `callIntent` URL params for a room.
+ * - Voice rooms (`isCallRoom()`): `join_existing` intent, `audio` callType (persistent channel).
+ * - DM rooms (≤2 joined members): `start_call` intent, `video` callType (1:1 video call).
+ * - Group rooms: `start_call` intent, `audio` callType.
+ */
+export function getCallIntentParams(room: Room | null | undefined): {
+  intent: 'join_existing' | 'start_call';
+  callIntentParam: 'audio' | 'video';
+} {
+  const isVoiceRoom = room?.isCallRoom() ?? false;
+  // Require room to be non-null: unknown/missing room should not be treated as a DM.
+  const isDmRoom = room != null && !isVoiceRoom && room.currentState.getJoinedMemberCount() <= 2;
+  return {
+    intent: isVoiceRoom ? 'join_existing' : 'start_call',
+    callIntentParam: isDmRoom ? 'video' : 'audio',
+  };
+}
 
 /**
  * Generates the URL for the Element Call widget.

--- a/src/app/features/call/SmallWidgetDriver.ts
+++ b/src/app/features/call/SmallWidgetDriver.ts
@@ -295,16 +295,26 @@ export class SmallWidgetDriver extends WidgetDriver {
 
   /**
    * @experimental Part of MSC4140 & MSC4157
+   * ClientWidgetApi dispatches three specific actions; the base WidgetDriver.updateDelayedEvent
+   * is never called. Implementing all three prevents 'Failed to override function' errors and
+   * the resulting 'Connection lost' in Element Call's MembershipManager.
    */
-  public async updateDelayedEvent(
-    delayId: string,
-    action: UpdateDelayedEventAction
-  ): Promise<void> {
+  public async cancelScheduledDelayedEvent(delayId: string): Promise<void> {
     const client = this.mxClient;
-
     if (!client) throw new Error('Not in a room or not attached to a client');
+    await client._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Cancel);
+  }
 
-    await client._unstable_updateDelayedEvent(delayId, action);
+  public async restartScheduledDelayedEvent(delayId: string): Promise<void> {
+    const client = this.mxClient;
+    if (!client) throw new Error('Not in a room or not attached to a client');
+    await client._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Restart);
+  }
+
+  public async sendScheduledDelayedEvent(delayId: string): Promise<void> {
+    const client = this.mxClient;
+    if (!client) throw new Error('Not in a room or not attached to a client');
+    await client._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Send);
   }
 
   /**

--- a/src/app/pages/client/call/CallProvider.tsx
+++ b/src/app/pages/client/call/CallProvider.tsx
@@ -35,8 +35,8 @@ interface CallContextState {
   registerActiveClientWidgetApi: (
     roomId: string | null,
     clientWidgetApi: ClientWidgetApi | null,
-    clientWidget: SmallWidget,
-    activeClientIframeRef: HTMLIFrameElement
+    clientWidget: SmallWidget | null,
+    activeClientIframeRef: HTMLIFrameElement | null
   ) => void;
   sendWidgetAction: <T extends IWidgetApiRequestData = IWidgetApiRequestData>(
     action: WidgetApiToWidgetAction | string,
@@ -46,6 +46,7 @@ interface CallContextState {
   isVideoEnabled: boolean;
   isChatOpen: boolean;
   isActiveCallReady: boolean;
+  resetActiveCallReady: () => void;
   toggleAudio: () => Promise<void>;
   toggleVideo: () => Promise<void>;
   toggleChat: () => Promise<void>;
@@ -280,6 +281,10 @@ export function CallProvider({ children }: CallProviderProps) {
     sendWidgetAction,
   ]);
 
+  const resetActiveCallReady = useCallback(() => {
+    setIsActiveCallReady(false);
+  }, []);
+
   const toggleChat = useCallback(async () => {
     const newState = !isChatOpen;
     setIsChatOpenState(newState);
@@ -300,6 +305,7 @@ export function CallProvider({ children }: CallProviderProps) {
       isAudioEnabled,
       isVideoEnabled,
       isActiveCallReady,
+      resetActiveCallReady,
       toggleAudio,
       toggleVideo,
       toggleChat,
@@ -318,6 +324,7 @@ export function CallProvider({ children }: CallProviderProps) {
       isAudioEnabled,
       isVideoEnabled,
       isActiveCallReady,
+      resetActiveCallReady,
       toggleAudio,
       toggleVideo,
       toggleChat,

--- a/src/app/pages/client/call/PersistentCallContainer.tsx
+++ b/src/app/pages/client/call/PersistentCallContainer.tsx
@@ -118,7 +118,12 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
             'm.call',
             newUrl,
             false,
-            getWidgetData(mx, roomIdToSet, {}, { skipLobby: true, intent: effectiveIntent, callIntent: callIntentParam }),
+            getWidgetData(
+              mx,
+              roomIdToSet,
+              {},
+              { skipLobby: true, intent: effectiveIntent, callIntent: callIntentParam }
+            ),
             roomIdToSet
           );
 
@@ -181,13 +186,27 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
       }
     }
     return undefined;
-  }, [isActiveCallReady, activeCallRoomId, mx, registerActiveClientWidgetApi, resetActiveCallReady, hangUp]);
+  }, [
+    isActiveCallReady,
+    activeCallRoomId,
+    mx,
+    registerActiveClientWidgetApi,
+    resetActiveCallReady,
+    hangUp,
+  ]);
 
   useEffect(() => {
     if (activeCallRoomId) {
       const intentOverride = postLobbyIntentRef.current ?? undefined;
       postLobbyIntentRef.current = null;
-      setupWidget(callWidgetApiRef, callSmallWidgetRef, callIframeRef, true, theme.kind, intentOverride);
+      setupWidget(
+        callWidgetApiRef,
+        callSmallWidgetRef,
+        callIframeRef,
+        true,
+        theme.kind,
+        intentOverride
+      );
     }
   }, [
     theme,

--- a/src/app/pages/client/call/PersistentCallContainer.tsx
+++ b/src/app/pages/client/call/PersistentCallContainer.tsx
@@ -35,7 +35,7 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
   const callIframeRef = useRef<HTMLIFrameElement | null>(null);
   const callWidgetApiRef = useRef<ClientWidgetApi | null>(null);
   const callSmallWidgetRef = useRef<SmallWidget | null>(null);
-  // After a non-voice room lobby join, reload EC with join_existing for proper in-call view.
+  // After any lobby join, reload EC with join_existing for proper in-call view.
   const hasReloadedAfterLobbyRef = useRef(false);
   const postLobbyIntentRef = useRef<'join_existing' | null>(null);
 
@@ -146,10 +146,11 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
     ]
   );
 
-  // After a non-voice room lobby join, poll until EC's call member state event has propagated
-  // to the room, then reload EC with intent=join_existing + skipLobby=true so it auto-joins
-  // the existing session and shows the full in-call grid. Hangs up if the session never
-  // appears (e.g. EC failed to send its state event) to avoid leaving the user stuck.
+  // After any lobby join, poll until EC's call member state event has propagated to the room,
+  // then reload EC with intent=join_existing + skipLobby=true so it auto-joins the existing
+  // session and shows the full in-call grid. Hangs up if the session never appears.
+  // Applies to all room types: DM/group (start_call) and voice rooms (join_existing) both
+  // hit the same timing issue where the in-call grid is not shown after the first join.
   useEffect(() => {
     if (!activeCallRoomId) {
       hasReloadedAfterLobbyRef.current = false;
@@ -157,8 +158,7 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
     }
     if (isActiveCallReady && !hasReloadedAfterLobbyRef.current) {
       const room = mx?.getRoom(activeCallRoomId);
-      // Voice rooms already use join_existing and work correctly; skip reload for them.
-      if (room && !room.isCallRoom()) {
+      if (room) {
         hasReloadedAfterLobbyRef.current = true;
         const POLL_INTERVAL_MS = 200;
         const TIMEOUT_MS = 10000;

--- a/src/app/pages/client/call/PersistentCallContainer.tsx
+++ b/src/app/pages/client/call/PersistentCallContainer.tsx
@@ -8,12 +8,14 @@ import {
   useRef,
 } from 'react';
 import { ClientWidgetApi } from 'matrix-widget-api';
+import { MatrixRTCSession } from 'matrix-js-sdk/lib/matrixrtc/MatrixRTCSession';
 import { Box } from 'folds';
 import {
   createVirtualWidget,
   SmallWidget,
   getWidgetData,
   getWidgetUrl,
+  getCallIntentParams,
 } from '$features/call/SmallWidget';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useClientConfig } from '$hooks/useClientConfig';
@@ -33,6 +35,9 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
   const callIframeRef = useRef<HTMLIFrameElement | null>(null);
   const callWidgetApiRef = useRef<ClientWidgetApi | null>(null);
   const callSmallWidgetRef = useRef<SmallWidget | null>(null);
+  // After a non-voice room lobby join, reload EC with join_existing for proper in-call view.
+  const hasReloadedAfterLobbyRef = useRef(false);
+  const postLobbyIntentRef = useRef<'join_existing' | null>(null);
 
   const {
     activeCallRoomId,
@@ -41,6 +46,8 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
     isActiveCallReady,
     registerActiveClientWidgetApi,
     activeClientWidget,
+    resetActiveCallReady,
+    hangUp,
   } = useCallState();
   const mx = useMatrixClient();
   const clientConfig = useClientConfig();
@@ -56,11 +63,15 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
       smallWidgetRef: MutableRefObject<SmallWidget | null>,
       iframeRef: MutableRefObject<HTMLIFrameElement | null>,
       skipLobby: boolean,
-      themeKind: ThemeKind | null
+      themeKind: ThemeKind | null,
+      intentOverride?: 'join_existing'
     ) => {
       if (mx?.getUserId()) {
         if (activeCallRoomId && !isActiveCallReady) {
           const roomIdToSet = activeCallRoomId;
+          const room = mx.getRoom(roomIdToSet);
+          const { intent: intentParam, callIntentParam } = getCallIntentParams(room);
+          const effectiveIntent = intentOverride ?? intentParam;
 
           const widgetId = `element-call-${roomIdToSet}-${Date.now()}`;
           const newUrl = getWidgetUrl(
@@ -69,11 +80,12 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
             clientConfig.elementCallUrl ?? '',
             widgetId,
             {
-              skipLobby: skipLobby.toString(),
+              skipLobby: (intentOverride === 'join_existing' ? true : skipLobby).toString(),
               returnToLobby: 'true',
               perParticipantE2EE: 'true',
               theme: themeKind,
-              callIntent: 'audio',
+              intent: effectiveIntent,
+              callIntent: callIntentParam,
             }
           );
 
@@ -106,7 +118,7 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
             'm.call',
             newUrl,
             false,
-            getWidgetData(mx, roomIdToSet, {}, { skipLobby: true, callIntent: 'audio' }),
+            getWidgetData(mx, roomIdToSet, {}, { skipLobby: true, intent: effectiveIntent, callIntent: callIntentParam }),
             roomIdToSet
           );
 
@@ -134,9 +146,48 @@ export function PersistentCallContainer({ children }: PersistentCallContainerPro
     ]
   );
 
+  // After a non-voice room lobby join, poll until EC's call member state event has propagated
+  // to the room, then reload EC with intent=join_existing + skipLobby=true so it auto-joins
+  // the existing session and shows the full in-call grid. Hangs up if the session never
+  // appears (e.g. EC failed to send its state event) to avoid leaving the user stuck.
+  useEffect(() => {
+    if (!activeCallRoomId) {
+      hasReloadedAfterLobbyRef.current = false;
+      return undefined;
+    }
+    if (isActiveCallReady && !hasReloadedAfterLobbyRef.current) {
+      const room = mx?.getRoom(activeCallRoomId);
+      // Voice rooms already use join_existing and work correctly; skip reload for them.
+      if (room && !room.isCallRoom()) {
+        hasReloadedAfterLobbyRef.current = true;
+        const POLL_INTERVAL_MS = 200;
+        const TIMEOUT_MS = 10000;
+        const startTime = Date.now();
+        const pollTimer = setInterval(() => {
+          if (MatrixRTCSession.callMembershipsForRoom(room).length > 0) {
+            clearInterval(pollTimer);
+            callSmallWidgetRef.current?.stopMessaging();
+            callWidgetApiRef.current = null;
+            callSmallWidgetRef.current = null;
+            registerActiveClientWidgetApi(activeCallRoomId, null, null, null);
+            postLobbyIntentRef.current = 'join_existing';
+            resetActiveCallReady();
+          } else if (Date.now() - startTime >= TIMEOUT_MS) {
+            clearInterval(pollTimer);
+            hangUp();
+          }
+        }, POLL_INTERVAL_MS);
+        return () => clearInterval(pollTimer);
+      }
+    }
+    return undefined;
+  }, [isActiveCallReady, activeCallRoomId, mx, registerActiveClientWidgetApi, resetActiveCallReady, hangUp]);
+
   useEffect(() => {
     if (activeCallRoomId) {
-      setupWidget(callWidgetApiRef, callSmallWidgetRef, callIframeRef, true, theme.kind);
+      const intentOverride = postLobbyIntentRef.current ?? undefined;
+      postLobbyIntentRef.current = null;
+      setupWidget(callWidgetApiRef, callSmallWidgetRef, callIframeRef, true, theme.kind, intentOverride);
     }
   }, [
     theme,


### PR DESCRIPTION
This ports Element Call fixes from Wally (a Cinny fork) to Sable.

## Fix 1 (Critical): SmallWidgetDriver missing delayed event methods — Connection lost for all users

matrix-widget-api's ClientWidgetApi dispatches three specific driver methods: `cancelScheduledDelayedEvent`, `restartScheduledDelayedEvent`, and `sendScheduledDelayedEvent`. Sable's SmallWidgetDriver only implemented the generic `updateDelayedEvent`, so all three fell through to the WidgetDriver base class, which throws 'Failed to override function'. Element Call's MembershipManager retried 10 times and gave up with **Connection lost** — affecting all users including those on Synapse.

**Fix:** Replace `updateDelayedEvent` with the three specific methods that ClientWidgetApi actually dispatches.

## Fix 2: Correct intent and callType per room type

Adds a `getCallIntentParams` helper that sets the right EC `intent` and `callIntent` per room type:
- **Voice rooms**: `join_existing` + `audio` (persistent channel)
- **DM rooms** (≤2 members): `start_call` + `video` (1:1 video call)
- **Group rooms**: `start_call` + `audio`

The `intent` URL parameter was previously silently dropped; it is now correctly passed to Element Call.

## Fix 3: Post-lobby reload for proper in-call view

After joining from the EC lobby in a non-voice room, EC showed only the control bar instead of the full in-call grid. This happened because EC's `start_call` session hadn't fully propagated its call member state event before the in-call view rendered.

**Fix:** After `io.element.join` fires, poll `MatrixRTCSession.callMembershipsForRoom` every 200ms. Once the call member state event arrives, reload EC with `intent=join_existing + skipLobby=true` so it auto-joins the existing session and shows the full in-call grid — identical to the behavior after a page refresh. If the session never appears within 10 seconds, `hangUp()` is called to avoid leaving the user stuck.

## Other

- Fix `registerActiveClientWidgetApi` interface: `clientWidget` and `iframeRef` params are nullable (needed for the reload teardown path)
- Add `resetActiveCallReady` to CallProvider context

🤖 Generated with [Claude Code](https://claude.com/claude-code)