### PR TITLE
feat: keyboard navigation shortcuts, ARIA form labels, and keyboard shortcuts page

### DIFF
--- a/.changeset/keyboard-navigation-aria-accessibility.md
+++ b/.changeset/keyboard-navigation-aria-accessibility.md
@@ -1,0 +1,5 @@
+---
+sable: minor
+---
+
+Add keyboard navigation shortcuts for unread rooms (Alt+N, Alt+Shift+Up/Down), ARIA form label associations for screen reader accessibility, and a keyboard shortcuts settings page.

--- a/src/app/components/GlobalKeyboardShortcuts.tsx
+++ b/src/app/components/GlobalKeyboardShortcuts.tsx
@@ -1,0 +1,121 @@
+/**
+ * Global keyboard shortcuts for navigation and accessibility.
+ *
+ * Shortcuts provided:
+ *   Alt+N              — jump to the highest-priority unread room
+ *   Alt+Shift+Down     — cycle forward through unread rooms
+ *   Alt+Shift+Up       — cycle backward through unread rooms
+ */
+import { useCallback, useRef } from 'react';
+import { useNavigate, useLocation, matchPath } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
+import { isKeyHotkey } from 'is-hotkey';
+import { useMatrixClient } from '$hooks/useMatrixClient';
+import { roomToParentsAtom } from '$state/room/roomToParents';
+import { mDirectAtom } from '$state/mDirectList';
+import { roomToUnreadAtom } from '$state/room/roomToUnread';
+import { useKeyDown } from '$hooks/useKeyDown';
+import {
+  getDirectRoomPath,
+  getHomeRoomPath,
+  getSpaceRoomPath,
+} from '$pages/pathUtils';
+import {
+  HOME_ROOM_PATH,
+  DIRECT_ROOM_PATH,
+  SPACE_ROOM_PATH,
+} from '$pages/paths';
+import { getCanonicalAliasOrRoomId } from '$utils/matrix';
+import { announce } from '$utils/announce';
+
+export function GlobalKeyboardShortcuts() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const mx = useMatrixClient();
+  const roomToParents = useAtomValue(roomToParentsAtom);
+  const mDirects = useAtomValue(mDirectAtom);
+  const roomToUnread = useAtomValue(roomToUnreadAtom);
+  const unreadIndexRef = useRef(0);
+
+  // Derive the current room ID from the URL so we know which room is active.
+  const roomMatch =
+    matchPath(HOME_ROOM_PATH, location.pathname) ??
+    matchPath(DIRECT_ROOM_PATH, location.pathname) ??
+    matchPath(SPACE_ROOM_PATH, location.pathname);
+  const roomIdOrAlias = roomMatch?.params.roomIdOrAlias
+    ? decodeURIComponent(roomMatch.params.roomIdOrAlias)
+    : undefined;
+  const currentRoomId = roomIdOrAlias
+    ? roomIdOrAlias.startsWith('!')
+      ? roomIdOrAlias
+      : mx.getRooms().find((r) => r.getCanonicalAlias() === roomIdOrAlias)?.roomId ?? null
+    : null;
+
+  /** Navigate to a room by ID and announce it to screen readers. */
+  const navigateToRoom = useCallback(
+    (roomId: string, remaining: number) => {
+      const roomIdOrAliasToNav = getCanonicalAliasOrRoomId(mx, roomId);
+      const isDirect = mDirects.has(roomId);
+      if (isDirect) {
+        navigate(getDirectRoomPath(roomIdOrAliasToNav));
+      } else {
+        const parents = roomToParents.get(roomId);
+        if (parents && parents.size > 0) {
+          const spaceId = Array.from(parents)[0];
+          const spaceIdOrAlias = getCanonicalAliasOrRoomId(mx, spaceId);
+          navigate(getSpaceRoomPath(spaceIdOrAlias, roomIdOrAliasToNav));
+        } else {
+          navigate(getHomeRoomPath(roomIdOrAliasToNav));
+        }
+      }
+      const roomName = mx.getRoom(roomId)?.name ?? 'Room';
+      const roomType = isDirect ? 'Direct Message' : 'Group Room';
+      announce(`${roomName}, ${roomType}. ${remaining} room${remaining === 1 ? '' : 's'} unread.`);
+    },
+    [mx, mDirects, roomToParents, navigate]
+  );
+
+  /** Alt+N: jump to the top-priority unread room and reset the cycle index. */
+  const handleNextUnreadKeyDown = useCallback(
+    (evt: KeyboardEvent) => {
+      if (!isKeyHotkey('alt+n', evt)) return;
+      const unreadEntries = Array.from(roomToUnread.entries())
+        .filter(([id, u]) => u.total > 0 && id !== currentRoomId)
+        .sort((a, b) => (b[1].highlight - a[1].highlight) || (b[1].total - a[1].total));
+      if (unreadEntries.length === 0) return;
+      evt.preventDefault();
+      unreadIndexRef.current = 0;
+      const [roomId] = unreadEntries[0];
+      navigateToRoom(roomId, unreadEntries.length - 1);
+    },
+    [roomToUnread, currentRoomId, navigateToRoom]
+  );
+
+  /** Alt+Shift+Down / Alt+Shift+Up: cycle through unread rooms. */
+  const handleUnreadNavKeyDown = useCallback(
+    (evt: KeyboardEvent) => {
+      const isDown = isKeyHotkey('alt+shift+down', evt);
+      const isUp = isKeyHotkey('alt+shift+up', evt);
+      if (!isDown && !isUp) return;
+      const unreadEntries = Array.from(roomToUnread.entries())
+        .filter(([, u]) => u.total > 0)
+        .sort((a, b) => (b[1].highlight - a[1].highlight) || (b[1].total - a[1].total));
+      if (unreadEntries.length === 0) return;
+      evt.preventDefault();
+      if (isDown) {
+        unreadIndexRef.current = (unreadIndexRef.current + 1) % unreadEntries.length;
+      } else {
+        unreadIndexRef.current =
+          (unreadIndexRef.current - 1 + unreadEntries.length) % unreadEntries.length;
+      }
+      const [roomId] = unreadEntries[unreadIndexRef.current];
+      navigateToRoom(roomId, unreadEntries.length - 1);
+    },
+    [roomToUnread, navigateToRoom]
+  );
+
+  useKeyDown(window, handleNextUnreadKeyDown);
+  useKeyDown(window, handleUnreadNavKeyDown);
+
+  return null;
+}

--- a/src/app/components/GlobalKeyboardShortcuts.tsx
+++ b/src/app/components/GlobalKeyboardShortcuts.tsx
@@ -15,16 +15,8 @@ import { roomToParentsAtom } from '$state/room/roomToParents';
 import { mDirectAtom } from '$state/mDirectList';
 import { roomToUnreadAtom } from '$state/room/roomToUnread';
 import { useKeyDown } from '$hooks/useKeyDown';
-import {
-  getDirectRoomPath,
-  getHomeRoomPath,
-  getSpaceRoomPath,
-} from '$pages/pathUtils';
-import {
-  HOME_ROOM_PATH,
-  DIRECT_ROOM_PATH,
-  SPACE_ROOM_PATH,
-} from '$pages/paths';
+import { getDirectRoomPath, getHomeRoomPath, getSpaceRoomPath } from '$pages/pathUtils';
+import { HOME_ROOM_PATH, DIRECT_ROOM_PATH, SPACE_ROOM_PATH } from '$pages/paths';
 import { getCanonicalAliasOrRoomId } from '$utils/matrix';
 import { announce } from '$utils/announce';
 
@@ -45,11 +37,15 @@ export function GlobalKeyboardShortcuts() {
   const roomIdOrAlias = roomMatch?.params.roomIdOrAlias
     ? decodeURIComponent(roomMatch.params.roomIdOrAlias)
     : undefined;
-  const currentRoomId = roomIdOrAlias
-    ? roomIdOrAlias.startsWith('!')
-      ? roomIdOrAlias
-      : mx.getRooms().find((r) => r.getCanonicalAlias() === roomIdOrAlias)?.roomId ?? null
-    : null;
+  let currentRoomId: string | null = null;
+  if (roomIdOrAlias) {
+    if (roomIdOrAlias.startsWith('!')) {
+      currentRoomId = roomIdOrAlias;
+    } else {
+      currentRoomId =
+        mx.getRooms().find((r) => r.getCanonicalAlias() === roomIdOrAlias)?.roomId ?? null;
+    }
+  }
 
   /** Navigate to a room by ID and announce it to screen readers. */
   const navigateToRoom = useCallback(
@@ -81,7 +77,7 @@ export function GlobalKeyboardShortcuts() {
       if (!isKeyHotkey('alt+n', evt)) return;
       const unreadEntries = Array.from(roomToUnread.entries())
         .filter(([id, u]) => u.total > 0 && id !== currentRoomId)
-        .sort((a, b) => (b[1].highlight - a[1].highlight) || (b[1].total - a[1].total));
+        .sort((a, b) => b[1].highlight - a[1].highlight || b[1].total - a[1].total);
       if (unreadEntries.length === 0) return;
       evt.preventDefault();
       unreadIndexRef.current = 0;
@@ -99,7 +95,7 @@ export function GlobalKeyboardShortcuts() {
       if (!isDown && !isUp) return;
       const unreadEntries = Array.from(roomToUnread.entries())
         .filter(([, u]) => u.total > 0)
-        .sort((a, b) => (b[1].highlight - a[1].highlight) || (b[1].total - a[1].total));
+        .sort((a, b) => b[1].highlight - a[1].highlight || b[1].total - a[1].total);
       if (unreadEntries.length === 0) return;
       evt.preventDefault();
       if (isDown) {

--- a/src/app/features/settings/Settings.tsx
+++ b/src/app/features/settings/Settings.tsx
@@ -35,6 +35,7 @@ import { Account } from './account';
 import { General } from './general';
 import { Cosmetics } from './cosmetics/Cosmetics';
 import { Experimental } from './experimental/Experimental';
+import { KeyboardShortcuts } from './keyboard-shortcuts';
 
 export enum SettingsPages {
   GeneralPage,
@@ -46,6 +47,7 @@ export enum SettingsPages {
   DeveloperToolsPage,
   ExperimentalPage,
   AboutPage,
+  KeyboardShortcutsPage,
 }
 
 type SettingsMenuItem = {
@@ -103,6 +105,11 @@ const useSettingsMenuItems = (): SettingsMenuItem[] =>
         page: SettingsPages.AboutPage,
         name: 'About',
         icon: Icons.Info,
+      },
+      {
+        page: SettingsPages.KeyboardShortcutsPage,
+        name: 'Keyboard Shortcuts',
+        icon: Icons.BlockCode,
       },
     ],
     []
@@ -259,6 +266,9 @@ export function Settings({ initialPage, requestClose }: SettingsProps) {
         <Experimental requestClose={handlePageRequestClose} />
       )}
       {activePage === SettingsPages.AboutPage && <About requestClose={handlePageRequestClose} />}
+      {activePage === SettingsPages.KeyboardShortcutsPage && (
+        <KeyboardShortcuts requestClose={handlePageRequestClose} />
+      )}
     </PageRoot>
   );
 }

--- a/src/app/features/settings/keyboard-shortcuts/KeyboardShortcuts.tsx
+++ b/src/app/features/settings/keyboard-shortcuts/KeyboardShortcuts.tsx
@@ -1,0 +1,150 @@
+/**
+ * Keyboard Shortcuts settings page.
+ *
+ * Lists all keyboard shortcuts available in Sable in a semantic,
+ * screen-reader-friendly dl/dt/dd structure.
+ */
+import { Box, Icon, IconButton, Icons, Scroll, Text, config } from 'folds';
+import { Page, PageContent, PageHeader } from '$components/page';
+
+type ShortcutEntry = {
+  keys: string;
+  description: string;
+};
+
+type ShortcutCategory = {
+  name: string;
+  shortcuts: ShortcutEntry[];
+};
+
+function formatKey(key: string): string {
+  const isMac =
+    typeof navigator !== 'undefined' && navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  return key
+    .replace(/\bmod\b/g, isMac ? '⌘' : 'Ctrl')
+    .replace(/\balt\b/gi, isMac ? '⌥' : 'Alt')
+    .replace(/\bshift\b/gi, '⇧')
+    .replace(/\+/g, '+');
+}
+
+const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
+  {
+    name: 'Navigation',
+    shortcuts: [
+      { keys: 'Alt+N', description: 'Jump to the highest-priority unread room' },
+      { keys: 'Alt+Shift+Down', description: 'Go to next unread room (cycle)' },
+      { keys: 'Alt+Shift+Up', description: 'Go to previous unread room (cycle)' },
+    ],
+  },
+  {
+    name: 'Messages',
+    shortcuts: [
+      { keys: 'Ctrl+Z / ⌘+Z', description: 'Undo in message editor' },
+      { keys: 'Ctrl+Shift+Z / ⌘+Shift+Z', description: 'Redo in message editor' },
+      { keys: 'Ctrl+B / ⌘+B', description: 'Bold' },
+      { keys: 'Ctrl+I / ⌘+I', description: 'Italic' },
+      { keys: 'Ctrl+U / ⌘+U', description: 'Underline' },
+    ],
+  },
+];
+
+function ShortcutRow({ keys, description }: ShortcutEntry) {
+  const parts = keys.split('/').map((k) => k.trim());
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: config.space.S400,
+        padding: `${config.space.S100} 0`,
+      }}
+    >
+      <Text size="T300" style={{ flex: 1, minWidth: 0 }}>
+        {description}
+      </Text>
+      <span style={{ flexShrink: 0 }} aria-label={parts.join(' or ')}>
+        {parts.map((part, i) => (
+          <span key={part}>
+            {part.split('+').map((seg, si, arr) => (
+              <span key={seg}>
+                <kbd
+                  style={{
+                    fontFamily: 'monospace',
+                    fontWeight: 'bold',
+                    padding: `0 ${config.space.S100}`,
+                    borderRadius: '3px',
+                    border: '1px solid currentColor',
+                    opacity: 0.8,
+                    fontSize: '0.85em',
+                  }}
+                >
+                  {formatKey(seg)}
+                </kbd>
+                {si < arr.length - 1 && (
+                  <span aria-hidden="true" style={{ margin: `0 2px` }}>
+                    +
+                  </span>
+                )}
+              </span>
+            ))}
+            {i < parts.length - 1 && (
+              <Text as="span" size="T200" priority="300" style={{ margin: `0 ${config.space.S100}` }}>
+                {' / '}
+              </Text>
+            )}
+          </span>
+        ))}
+      </span>
+    </div>
+  );
+}
+
+type KeyboardShortcutsProps = {
+  requestClose: () => void;
+};
+export function KeyboardShortcuts({ requestClose }: KeyboardShortcutsProps) {
+  return (
+    <Page>
+      <PageHeader outlined={false}>
+        <Box grow="Yes" gap="200">
+          <Box grow="Yes" alignItems="Center" gap="200">
+            <Text size="H3" as="h1" truncate>
+              Keyboard Shortcuts
+            </Text>
+          </Box>
+          <Box shrink="No">
+            <IconButton onClick={requestClose} variant="Surface" aria-label="Close keyboard shortcuts">
+              <Icon src={Icons.Cross} />
+            </IconButton>
+          </Box>
+        </Box>
+      </PageHeader>
+      <Box grow="Yes">
+        <Scroll hideTrack visibility="Hover">
+          <PageContent>
+            <Box direction="Column" gap="600">
+              {SHORTCUT_CATEGORIES.map((category) => (
+                <Box key={category.name} direction="Column" gap="200">
+                  <Text size="L400" as="h2">
+                    {category.name}
+                  </Text>
+                  <dl style={{ margin: 0 }}>
+                    {category.shortcuts.map((entry) => (
+                      <div key={entry.description}>
+                        <dt style={{ display: 'none' }}>{entry.keys}</dt>
+                        <dd style={{ margin: 0 }}>
+                          <ShortcutRow keys={entry.keys} description={entry.description} />
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </Box>
+              ))}
+            </Box>
+          </PageContent>
+        </Scroll>
+      </Box>
+    </Page>
+  );
+}

--- a/src/app/features/settings/keyboard-shortcuts/KeyboardShortcuts.tsx
+++ b/src/app/features/settings/keyboard-shortcuts/KeyboardShortcuts.tsx
@@ -89,7 +89,12 @@ function ShortcutRow({ keys, description }: ShortcutEntry) {
               </span>
             ))}
             {i < parts.length - 1 && (
-              <Text as="span" size="T200" priority="300" style={{ margin: `0 ${config.space.S100}` }}>
+              <Text
+                as="span"
+                size="T200"
+                priority="300"
+                style={{ margin: `0 ${config.space.S100}` }}
+              >
                 {' / '}
               </Text>
             )}
@@ -114,7 +119,11 @@ export function KeyboardShortcuts({ requestClose }: KeyboardShortcutsProps) {
             </Text>
           </Box>
           <Box shrink="No">
-            <IconButton onClick={requestClose} variant="Surface" aria-label="Close keyboard shortcuts">
+            <IconButton
+              onClick={requestClose}
+              variant="Surface"
+              aria-label="Close keyboard shortcuts"
+            >
               <Icon src={Icons.Cross} />
             </IconButton>
           </Box>

--- a/src/app/features/settings/keyboard-shortcuts/index.ts
+++ b/src/app/features/settings/keyboard-shortcuts/index.ts
@@ -1,0 +1,1 @@
+export * from './KeyboardShortcuts';

--- a/src/app/pages/Router.tsx
+++ b/src/app/pages/Router.tsx
@@ -73,6 +73,7 @@ import { Create } from './client/create';
 import { CallProvider } from './client/call/CallProvider';
 import { PersistentCallContainer } from './client/call/PersistentCallContainer';
 import { ToRoomEvent } from './client/ToRoomEvent';
+import { GlobalKeyboardShortcuts } from '$components/GlobalKeyboardShortcuts';
 
 /**
  * Returns true if there is at least one stored session.
@@ -170,6 +171,22 @@ export const createRouter = (clientConfig: ClientConfig, screenSize: ScreenSize)
                       <CreateSpaceModalRenderer />
                       <RoomSettingsRenderer />
                       <SpaceSettingsRenderer />
+                      <GlobalKeyboardShortcuts />
+                      {/* Screen reader live region — populated by announce() in utils/announce.ts */}
+                      <div
+                        id="sable-announcements"
+                        role="status"
+                        aria-live="polite"
+                        aria-atomic="true"
+                        style={{
+                          position: 'absolute',
+                          width: '1px',
+                          height: '1px',
+                          overflow: 'hidden',
+                          clip: 'rect(0,0,0,0)',
+                          whiteSpace: 'nowrap',
+                        }}
+                      />
                       <ReceiveSelfDeviceVerification />
                       <AutoRestoreBackupOnVerification />
                     </ClientNonUIFeatures>

--- a/src/app/pages/Router.tsx
+++ b/src/app/pages/Router.tsx
@@ -23,6 +23,7 @@ import { getFallbackSession, MATRIX_SESSIONS_KEY, Sessions } from '$state/sessio
 import { getLocalStorageItem } from '$state/utils/atomWithLocalStorage';
 import { NotificationJumper } from '$hooks/useNotificationJumper';
 import { SearchModalRenderer } from '$features/search';
+import { GlobalKeyboardShortcuts } from '$components/GlobalKeyboardShortcuts';
 import { AuthLayout, Login, Register, ResetPassword } from './auth';
 import {
   DIRECT_PATH,
@@ -73,7 +74,6 @@ import { Create } from './client/create';
 import { CallProvider } from './client/call/CallProvider';
 import { PersistentCallContainer } from './client/call/PersistentCallContainer';
 import { ToRoomEvent } from './client/ToRoomEvent';
-import { GlobalKeyboardShortcuts } from '$components/GlobalKeyboardShortcuts';
 
 /**
  * Returns true if there is at least one stored session.

--- a/src/app/pages/auth/login/PasswordLoginForm.tsx
+++ b/src/app/pages/auth/login/PasswordLoginForm.tsx
@@ -230,7 +230,14 @@ export function PasswordLoginForm({ defaultUsername, defaultEmail }: PasswordLog
         <Text as="label" htmlFor="login-password-input" size="L400" priority="300">
           Password
         </Text>
-        <PasswordInput id="login-password-input" name="passwordInput" variant="Background" size="500" outlined required />
+        <PasswordInput
+          id="login-password-input"
+          name="passwordInput"
+          variant="Background"
+          size="500"
+          outlined
+          required
+        />
         <Box alignItems="Start" justifyContent="SpaceBetween" gap="200">
           {loginState.status === AsyncStatus.Error && (
             <>

--- a/src/app/pages/auth/login/PasswordLoginForm.tsx
+++ b/src/app/pages/auth/login/PasswordLoginForm.tsx
@@ -199,10 +199,11 @@ export function PasswordLoginForm({ defaultUsername, defaultEmail }: PasswordLog
   return (
     <Box as="form" onSubmit={handleSubmit} direction="Inherit" gap="400">
       <Box direction="Column" gap="100">
-        <Text as="label" size="L400" priority="300">
+        <Text as="label" htmlFor="login-username-input" size="L400" priority="300">
           Username
         </Text>
         <Input
+          id="login-username-input"
           defaultValue={defaultUsername ?? defaultEmail}
           style={{ paddingRight: config.space.S300 }}
           name="usernameInput"
@@ -226,10 +227,10 @@ export function PasswordLoginForm({ defaultUsername, defaultEmail }: PasswordLog
         )}
       </Box>
       <Box direction="Column" gap="100">
-        <Text as="label" size="L400" priority="300">
+        <Text as="label" htmlFor="login-password-input" size="L400" priority="300">
           Password
         </Text>
-        <PasswordInput name="passwordInput" variant="Background" size="500" outlined required />
+        <PasswordInput id="login-password-input" name="passwordInput" variant="Background" size="500" outlined required />
         <Box alignItems="Start" justifyContent="SpaceBetween" gap="200">
           {loginState.status === AsyncStatus.Error && (
             <>

--- a/src/app/pages/auth/register/PasswordRegisterForm.tsx
+++ b/src/app/pages/auth/register/PasswordRegisterForm.tsx
@@ -315,7 +315,12 @@ export function PasswordRegisterForm({
                 )}
               </Box>
               <Box direction="Column" gap="100">
-                <Text as="label" htmlFor="register-confirm-password-input" size="L400" priority="300">
+                <Text
+                  as="label"
+                  htmlFor="register-confirm-password-input"
+                  size="L400"
+                  priority="300"
+                >
                   Confirm Password
                 </Text>
                 <PasswordInput

--- a/src/app/pages/auth/register/PasswordRegisterForm.tsx
+++ b/src/app/pages/auth/register/PasswordRegisterForm.tsx
@@ -258,10 +258,11 @@ export function PasswordRegisterForm({
     <>
       <Box as="form" onSubmit={handleSubmit} direction="Inherit" gap="400">
         <Box direction="Column" gap="100">
-          <Text as="label" size="L400" priority="300">
+          <Text as="label" htmlFor="register-username-input" size="L400" priority="300">
             Username
           </Text>
           <Input
+            id="register-username-input"
             variant="Background"
             defaultValue={defaultUsername}
             name="usernameInput"
@@ -283,10 +284,11 @@ export function PasswordRegisterForm({
           {(match, doMatch, passRef, confPassRef) => (
             <>
               <Box direction="Column" gap="100">
-                <Text as="label" size="L400" priority="300">
+                <Text as="label" htmlFor="register-password-input" size="L400" priority="300">
                   Password
                 </Text>
                 <PasswordInput
+                  id="register-password-input"
                   ref={passRef}
                   onChange={doMatch}
                   name="passwordInput"
@@ -313,10 +315,11 @@ export function PasswordRegisterForm({
                 )}
               </Box>
               <Box direction="Column" gap="100">
-                <Text as="label" size="L400" priority="300">
+                <Text as="label" htmlFor="register-confirm-password-input" size="L400" priority="300">
                   Confirm Password
                 </Text>
                 <PasswordInput
+                  id="register-confirm-password-input"
                   ref={confPassRef}
                   onChange={doMatch}
                   name="confirmPasswordInput"
@@ -332,12 +335,13 @@ export function PasswordRegisterForm({
         </ConfirmPasswordMatch>
         {hasStageInFlows(uiaFlows, AuthType.RegistrationToken) && (
           <Box direction="Column" gap="100">
-            <Text as="label" size="L400" priority="300">
+            <Text as="label" htmlFor="register-token-input" size="L400" priority="300">
               {requiredStageInFlows(uiaFlows, AuthType.RegistrationToken)
                 ? 'Registration Token'
                 : 'Registration Token (Optional)'}
             </Text>
             <Input
+              id="register-token-input"
               variant="Background"
               defaultValue={defaultRegisterToken}
               name="tokenInput"
@@ -349,10 +353,11 @@ export function PasswordRegisterForm({
         )}
         {hasStageInFlows(uiaFlows, AuthType.Email) && (
           <Box direction="Column" gap="100">
-            <Text as="label" size="L400" priority="300">
+            <Text as="label" htmlFor="register-email-input" size="L400" priority="300">
               {requiredStageInFlows(uiaFlows, AuthType.Email) ? 'Email' : 'Email (Optional)'}
             </Text>
             <Input
+              id="register-email-input"
               variant="Background"
               defaultValue={defaultEmail}
               name="emailInput"

--- a/src/app/utils/announce.ts
+++ b/src/app/utils/announce.ts
@@ -1,0 +1,12 @@
+/**
+ * Announce a message to screen readers via the live region injected by Router.tsx.
+ * Clears then re-sets the text so repeated identical messages are still announced.
+ */
+export function announce(msg: string) {
+  const el = document.getElementById('sable-announcements');
+  if (!el) return;
+  el.textContent = '';
+  requestAnimationFrame(() => {
+    el.textContent = msg;
+  });
+}


### PR DESCRIPTION
## Summary

This PR ports three focused accessibility improvements from the [Wally/Cinny fork](https://codeberg.org/Wally/cinny-web).

### 1. Keyboard navigation for unread rooms (`GlobalKeyboardShortcuts.tsx`)

New global keyboard shortcuts to navigate unread rooms without a mouse:

| Shortcut | Action |
|----------|--------|
| `Alt+N` | Jump to the highest-priority unread room (sorted by highlights first, then total unread) |
| `Alt+Shift+Down` | Cycle forward through unread rooms |
| `Alt+Shift+Up` | Cycle backward through unread rooms |

Each navigation announces the room name, type (DM or group), and remaining unread count to screen readers via a visually-hidden `aria-live="polite"` region (also new in this PR). The navigation correctly handles DM rooms, space rooms, and home rooms.

### 2. ARIA label associations on auth forms

Both `PasswordLoginForm` and `PasswordRegisterForm` rendered `<label>` elements via `Text as="label"` without `htmlFor`/`id` pairing. Screen readers (NVDA, VoiceOver, etc.) cannot associate unlabelled inputs with their labels, so the form fields were announced as unlabelled.

**Fixed:** all label/input pairs now have matching `htmlFor`/`id` attributes:
- Login: `login-username-input`, `login-password-input`
- Register: `register-username-input`, `register-password-input`, `register-confirm-password-input`, `register-token-input`, `register-email-input`

### 3. Keyboard Shortcuts settings page

A new **Keyboard Shortcuts** entry in Settings (accessible from the settings sidebar) lists all available keyboard shortcuts in a structured layout using semantic `<kbd>` elements. Keys are formatted correctly for macOS (⌥, ⇧) vs other platforms.

### Infrastructure

- `src/app/utils/announce.ts` — lightweight utility that writes to the `aria-live` region so screen readers announce navigation events
- `aria-live="polite"` visually-hidden div added to the authenticated route in `Router.tsx`

## What was deliberately NOT ported

- F6 section-based keyboard navigation — too tightly coupled to Wally's specific DOM IDs and section structure
- Notification sounds changes — Sable already has a solid OGG-based notification sound system; the additional Web Audio API tones from Wally would not add enough value relative to complexity
- Call/video shortcuts — Sable's call architecture is different from Wally's

## Test plan

- [ ] Log out and log in: verify that screen readers (NVDA/JAWS/VoiceOver) announce the Username and Password field labels when focused
- [ ] Register: verify all registration form fields (Username, Password, Confirm Password, Registration Token, Email) are announced correctly by screen readers
- [ ] Press Alt+N in a session with unread rooms: verify it navigates to the highest-priority unread room
- [ ] Press Alt+Shift+Down/Up: verify it cycles through unread rooms and announces each one
- [ ] Open Settings → Keyboard Shortcuts: verify the shortcuts page renders correctly
- [ ] Verify no regressions on notification sounds, call functionality, or room navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)