### PR TITLE
Add setting to disable element-call disabling of picture in picture

### DIFF
--- a/.changeset/add_setting_to_enable_picture_in_picture_in_element_call.md
+++ b/.changeset/add_setting_to_enable_picture_in_picture_in_element_call.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+# Add setting to enable picture-in-picture in element-call

--- a/.changeset/add_setting_to_enable_picture_in_picture_in_element_call.md
+++ b/.changeset/add_setting_to_enable_picture_in_picture_in_element_call.md
@@ -1,5 +1,5 @@
 ---
-sable: patch
+sable: minor
 ---
 
 # Add setting to enable picture-in-picture in element-call

--- a/src/app/features/call/CallView.tsx
+++ b/src/app/features/call/CallView.tsx
@@ -26,6 +26,8 @@ import { usePowerLevelsContext } from '$hooks/usePowerLevels';
 import { useRoomName } from '$hooks/useRoomMeta';
 import { useAtomValue } from 'jotai';
 import { nicknamesAtom } from '$state/nicknames';
+import { settingsAtom } from '$state/settings';
+import { useSetting } from '$state/hooks/settings';
 import * as css from './CallView.css';
 import { CallViewUser } from './CallViewUser';
 
@@ -138,9 +140,24 @@ export function CallView({ room }: { room: Room }) {
     wait: 50,
     immediate: false,
   });
+
+  const [allowPipVideos] = useSetting(settingsAtom, 'allowPipVideos');
+
   useEffect(() => {
     const iframeElement = activeIframeDisplayRef?.current;
     const hostElement = iframeHostRef?.current;
+
+    if (allowPipVideos) {
+      const removeDisablePictureInPicture = (mutated: any) => {
+        mutated.forEach((event: any) => {
+          Array.from(event.target.getElementsByTagName('video')).forEach((video: any) => {
+            video.removeAttribute('disablepictureinpicture');
+          });
+        });
+      };
+      const pipObserver = new MutationObserver(removeDisablePictureInPicture);
+      pipObserver.observe(iframeElement?.contentDocument!, { subtree: true, childList: true });
+    }
 
     if (room.isCallRoom() || (callIsCurrentAndReady && iframeElement && hostElement)) {
       applyFixedPositioningToIframe();
@@ -172,6 +189,7 @@ export function CallView({ room }: { room: Room }) {
     debouncedApplyFixedPositioning,
     callIsCurrentAndReady,
     room,
+    allowPipVideos,
   ]);
 
   const handleJoinVCClick: MouseEventHandler<HTMLElement> = (evt) => {

--- a/src/app/features/settings/cosmetics/Cosmetics.tsx
+++ b/src/app/features/settings/cosmetics/Cosmetics.tsx
@@ -240,6 +240,23 @@ function IdentityCosmetics() {
   );
 }
 
+function VideoCosmetics() {
+  const [allowPipVideos, setPipVideos] = useSetting(settingsAtom, 'allowPipVideos');
+
+  return (
+    <Box direction="Column" gap="100">
+      <Text size="L400">Video</Text>
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Picture in Picture Videos"
+          description="If your browser has it enabled, allows you to pop out the videos in the video call interface. Does not apply retroactively to current joined voice rooms."
+          after={<Switch variant="Primary" value={allowPipVideos} onChange={setPipVideos} />}
+        />
+      </SequenceCard>
+    </Box>
+  );
+}
+
 type CosmeticsProps = {
   requestClose: () => void;
 };
@@ -269,6 +286,7 @@ export function Cosmetics({ requestClose }: CosmeticsProps) {
               <IdentityCosmetics />
               <JumboEmoji />
               <Privacy />
+              <VideoCosmetics />
             </Box>
           </PageContent>
         </Scroll>

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -43,6 +43,7 @@ export interface Settings {
   encUrlPreview: boolean;
   showHiddenEvents: boolean;
   legacyUsernameColor: boolean;
+  allowPipVideos: boolean;
 
   usePushNotifications: boolean;
   useInAppNotifications: boolean;
@@ -105,6 +106,7 @@ const defaultSettings: Settings = {
   encUrlPreview: false,
   showHiddenEvents: false,
   legacyUsernameColor: false,
+  allowPipVideos: false,
 
   // Push notifications (SW/Sygnal): default on for mobile, opt-in on desktop.
   // In-app pill banner: default on for mobile (primary foreground alert), opt-in on desktop.


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Element-call ships with adding `disablePictureInPicture` to the video elements. This PR adds a setting that disables those so you can choose whether to pop out the videos.


<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
