### PR TITLE
fix(rendering): sliding sync render performance, encrypted room flash fix, and scroll view fix

### DIFF
--- a/.changeset/sliding_sync_rendering_optimisations.md
+++ b/.changeset/sliding_sync_rendering_optimisations.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Sliding Sync performance: room nav items no longer re-render on unrelated updates; nickname atom subscriptions scoped per-user; fixed unread state and room-to-parent atom churn.

--- a/.changeset/timeline_rendering_polish.md
+++ b/.changeset/timeline_rendering_polish.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Timeline: room timeline always scrolls to the live end when opening a room or on subscription refresh, fixing a regression where rooms with unread messages would jump to the read marker instead; improved unread marker detection; reduced rendering jitter.

--- a/src/app/features/room-nav/RoomNavItem.tsx
+++ b/src/app/features/room-nav/RoomNavItem.tsx
@@ -1,4 +1,12 @@
-import { MouseEventHandler, forwardRef, useState, MouseEvent, useEffect } from 'react';
+import {
+  MouseEventHandler,
+  forwardRef,
+  memo,
+  useMemo,
+  useState,
+  MouseEvent,
+  useEffect,
+} from 'react';
 import { EventType, Room, RoomEvent as RoomEventEnum } from '$types/matrix-sdk';
 import {
   Avatar,
@@ -25,12 +33,17 @@ import { useNavigate } from 'react-router-dom';
 import { NavButton, NavItem, NavItemContent, NavItemOptions } from '$components/nav';
 import { UnreadBadge, UnreadBadgeCenter } from '$components/unread-badge';
 import { RoomAvatar, RoomIcon } from '$components/room-avatar';
-import { getDirectRoomAvatarUrl, getRoomAvatarUrl, roomHaveUnread } from '$utils/room';
+import {
+  getDirectRoomAvatarUrl,
+  getRoomAvatarUrl,
+  getStateEvent,
+  roomHaveUnread,
+} from '$utils/room';
 import { nameInitials } from '$utils/common';
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { useRoomUnread } from '$state/hooks/unread';
 import { roomToUnreadAtom } from '$state/room/roomToUnread';
-import { usePowerLevels } from '$hooks/usePowerLevels';
+import { usePowerLevels, readPowerLevel, IPowerLevels } from '$hooks/usePowerLevels';
 import { copyToClipboard } from '$utils/dom';
 import { markAsRead } from '$utils/notifications';
 import { UseStateProvider } from '$components/UseStateProvider';
@@ -59,8 +72,7 @@ import { useCallMembers } from '$hooks/useCallMemberships';
 import { useRoomNavigate } from '$hooks/useRoomNavigate';
 import { ScreenSize, useScreenSizeContext } from '$hooks/useScreenSize';
 import { useRoomName } from '$hooks/useRoomMeta';
-import { useAtomValue } from 'jotai';
-import { nicknamesAtom } from '$state/nicknames';
+import { StateEvent } from '$types/matrix/room';
 import { RoomNavUser } from './RoomNavUser';
 
 /**
@@ -250,281 +262,287 @@ type RoomNavItemProps = {
   showAvatar?: boolean;
   direct?: boolean;
 };
-export function RoomNavItem({
-  room,
-  selected,
-  showAvatar,
-  direct,
-  notificationMode,
-  linkPath,
-}: RoomNavItemProps) {
-  const mx = useMatrixClient();
-  const useAuthentication = useMediaAuthentication();
-  const [hover, setHover] = useState(false);
-  const { hoverProps } = useHover({ onHoverChange: setHover });
-  const { focusWithinProps } = useFocusWithin({ onFocusWithinChange: setHover });
-  const [menuAnchor, setMenuAnchor] = useState<RectCords>();
-  const unread = useRoomUnread(room.roomId, roomToUnreadAtom);
-  const hasRoomUnread = useRoomHasUnread(room);
-  const typingMember = useRoomTypingMember(room.roomId).filter(
-    (receipt) => receipt.userId !== mx.getUserId()
-  );
+// Wrapped in memo to prevent re-renders when parent components re-render due
+// to atom changes (e.g. roomToParentsAtom, mDirectAtom). With sliding sync,
+// these atoms update frequently as rooms and state events arrive, and without
+// memo every visible RoomNavItem re-renders even if its own props are unchanged.
+export const RoomNavItem = memo(
+  ({ room, selected, showAvatar, direct, notificationMode, linkPath }: RoomNavItemProps) => {
+    const mx = useMatrixClient();
+    const useAuthentication = useMediaAuthentication();
+    const [hover, setHover] = useState(false);
+    const { hoverProps } = useHover({ onHoverChange: setHover });
+    const { focusWithinProps } = useFocusWithin({ onFocusWithinChange: setHover });
+    const [menuAnchor, setMenuAnchor] = useState<RectCords>();
+    const unread = useRoomUnread(room.roomId, roomToUnreadAtom);
+    const hasRoomUnread = useRoomHasUnread(room);
+    const typingMember = useRoomTypingMember(room.roomId).filter(
+      (receipt) => receipt.userId !== mx.getUserId()
+    );
 
-  const {
-    isActiveCallReady,
-    activeCallRoomId,
-    setActiveCallRoomId,
-    setViewedCallRoomId,
-    isChatOpen,
-    toggleChat,
-    hangUp,
-  } = useCallState();
+    const {
+      isActiveCallReady,
+      activeCallRoomId,
+      setActiveCallRoomId,
+      setViewedCallRoomId,
+      isChatOpen,
+      toggleChat,
+      hangUp,
+    } = useCallState();
 
-  const isActiveCall = isActiveCallReady && activeCallRoomId === room.roomId;
-  const callMemberships = useCallMembers(mx, room.roomId);
+    const isActiveCall = isActiveCallReady && activeCallRoomId === room.roomId;
+    const callMemberships = useCallMembers(mx, room.roomId);
 
-  const powerLevels = usePowerLevels(room);
-  const creators = useRoomCreators(room);
-  const nicknames = useAtomValue(nicknamesAtom);
-  const dmUserId = direct ? room.getAvatarFallbackMember()?.userId : undefined;
-  const matrixRoomName = useRoomName(room);
-  const roomName = (dmUserId && nicknames[dmUserId]) || matrixRoomName;
+    const roomName = useRoomName(room);
 
-  const permissions = useRoomPermissions(creators, powerLevels);
-  const canJoinCall = permissions.event(EventType.GroupCallMemberPrefix, mx.getSafeUserId());
+    // canJoinCall is only used in the click handler for call rooms, not in rendered output.
+    // Computing it non-reactively avoids registering a RoomStateEvent.Events listener per
+    // nav item just for this rarely-changing value. usePowerLevels / useRoomPermissions
+    // still run inside RoomNavItemMenu, which is only mounted on hover.
+    const canJoinCall = useMemo(() => {
+      if (!room.isCallRoom()) return false;
+      const userId = mx.getSafeUserId();
+      const plContent =
+        getStateEvent(room, StateEvent.RoomPowerLevels)?.getContent<IPowerLevels>() ?? {};
+      return (
+        readPowerLevel.user(plContent, userId) >=
+        readPowerLevel.event(plContent, EventType.GroupCallMemberPrefix)
+      );
+    }, [room, mx]);
 
-  const { navigateRoom } = useRoomNavigate();
-  const navigate = useNavigate();
+    const { navigateRoom } = useRoomNavigate();
+    const navigate = useNavigate();
 
-  const screenSize = useScreenSizeContext();
-  const isMobile = screenSize === ScreenSize.Mobile;
+    const screenSize = useScreenSizeContext();
+    const isMobile = screenSize === ScreenSize.Mobile;
 
-  const handleContextMenu: MouseEventHandler<HTMLElement> = (evt) => {
-    evt.preventDefault();
-    setMenuAnchor({
-      x: evt.clientX,
-      y: evt.clientY,
-      width: 0,
-      height: 0,
-    });
-  };
+    const handleContextMenu: MouseEventHandler<HTMLElement> = (evt) => {
+      evt.preventDefault();
+      setMenuAnchor({
+        x: evt.clientX,
+        y: evt.clientY,
+        width: 0,
+        height: 0,
+      });
+    };
 
-  const handleOpenMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
-    setMenuAnchor(evt.currentTarget.getBoundingClientRect());
-  };
+    const handleOpenMenu: MouseEventHandler<HTMLButtonElement> = (evt) => {
+      setMenuAnchor(evt.currentTarget.getBoundingClientRect());
+    };
 
-  const handleNavItemClick: MouseEventHandler<HTMLElement> = (evt) => {
-    if (room.isCallRoom()) {
-      if (!isMobile) {
-        if (!isActiveCall && canJoinCall) {
-          hangUp();
-          setActiveCallRoomId(room.roomId);
+    const handleNavItemClick: MouseEventHandler<HTMLElement> = (evt) => {
+      if (room.isCallRoom()) {
+        if (!isMobile) {
+          if (!isActiveCall && canJoinCall) {
+            hangUp();
+            setActiveCallRoomId(room.roomId);
+          } else {
+            navigateRoom(room.roomId);
+          }
         } else {
+          evt.stopPropagation();
+          if (isChatOpen) toggleChat();
+          setViewedCallRoomId(room.roomId);
           navigateRoom(room.roomId);
         }
       } else {
-        evt.stopPropagation();
-        if (isChatOpen) toggleChat();
-        setViewedCallRoomId(room.roomId);
-        navigateRoom(room.roomId);
+        navigate(linkPath);
       }
-    } else {
+    };
+
+    const handleChatButtonClick = (evt: MouseEvent<HTMLButtonElement>) => {
+      evt.stopPropagation();
+      toggleChat();
+      setViewedCallRoomId(room.roomId);
       navigate(linkPath);
+    };
+
+    const optionsVisible = hover || !!menuAnchor;
+    let unreadCount = 0;
+    if (unread) {
+      unreadCount = unread.highlight > 0 ? unread.highlight : unread.total;
     }
-  };
+    const ariaLabel = [
+      roomName,
+      room.isCallRoom()
+        ? [
+            'Call Room',
+            isActiveCall && 'Currently in Call',
+            callMemberships.length && `${callMemberships.length} in Call`,
+          ]
+        : 'Text Room',
+      unread?.total && `${unread.total} Messages`,
+    ]
+      .flat()
+      .filter(Boolean)
+      .join(', ');
 
-  const handleChatButtonClick = (evt: MouseEvent<HTMLButtonElement>) => {
-    evt.stopPropagation();
-    toggleChat();
-    setViewedCallRoomId(room.roomId);
-    navigate(linkPath);
-  };
-
-  const optionsVisible = hover || !!menuAnchor;
-  let unreadCount = 0;
-  if (unread) {
-    unreadCount = unread.highlight > 0 ? unread.highlight : unread.total;
-  }
-  const ariaLabel = [
-    roomName,
-    room.isCallRoom()
-      ? [
-          'Call Room',
-          isActiveCall && 'Currently in Call',
-          callMemberships.length && `${callMemberships.length} in Call`,
-        ]
-      : 'Text Room',
-    unread?.total && `${unread.total} Messages`,
-  ]
-    .flat()
-    .filter(Boolean)
-    .join(', ');
-
-  return (
-    <Box direction="Column" grow="Yes">
-      <NavItem
-        variant="Background"
-        radii="400"
-        highlight={unread !== undefined || hasRoomUnread}
-        aria-selected={selected}
-        data-hover={!!menuAnchor}
-        onContextMenu={handleContextMenu}
-        {...hoverProps}
-        {...focusWithinProps}
-      >
-        <NavButton onClick={handleNavItemClick} aria-label={ariaLabel}>
-          <NavItemContent>
-            <Box as="span" grow="Yes" alignItems="Center" gap="200">
-              <Avatar size="200" radii="400">
-                {showAvatar ? (
-                  <RoomAvatar
-                    roomId={room.roomId}
-                    src={
-                      direct
-                        ? getDirectRoomAvatarUrl(mx, room, 96, useAuthentication)
-                        : getRoomAvatarUrl(mx, room, 96, useAuthentication)
-                    }
-                    uniformIcons
-                    alt={roomName}
-                    renderFallback={() => (
-                      <Text as="span" size="H6">
-                        {nameInitials(roomName)}
-                      </Text>
-                    )}
-                  />
-                ) : (
-                  <RoomIcon
-                    style={{
-                      opacity:
-                        unread || hasRoomUnread || isActiveCall
-                          ? config.opacity.P500
-                          : config.opacity.P300,
-                    }}
-                    filled={selected || isActiveCall}
-                    size="100"
-                    joinRule={room.getJoinRule()}
-                    roomType={room.getType()}
+    return (
+      <Box direction="Column" grow="Yes">
+        <NavItem
+          variant="Background"
+          radii="400"
+          highlight={unread !== undefined || hasRoomUnread}
+          aria-selected={selected}
+          data-hover={!!menuAnchor}
+          onContextMenu={handleContextMenu}
+          {...hoverProps}
+          {...focusWithinProps}
+        >
+          <NavButton onClick={handleNavItemClick} aria-label={ariaLabel}>
+            <NavItemContent>
+              <Box as="span" grow="Yes" alignItems="Center" gap="200">
+                <Avatar size="200" radii="400">
+                  {showAvatar ? (
+                    <RoomAvatar
+                      roomId={room.roomId}
+                      src={
+                        direct
+                          ? getDirectRoomAvatarUrl(mx, room, 96, useAuthentication)
+                          : getRoomAvatarUrl(mx, room, 96, useAuthentication)
+                      }
+                      uniformIcons
+                      alt={roomName}
+                      renderFallback={() => (
+                        <Text as="span" size="H6">
+                          {nameInitials(roomName)}
+                        </Text>
+                      )}
+                    />
+                  ) : (
+                    <RoomIcon
+                      style={{
+                        opacity:
+                          unread || hasRoomUnread || isActiveCall
+                            ? config.opacity.P500
+                            : config.opacity.P300,
+                      }}
+                      filled={selected || isActiveCall}
+                      size="100"
+                      joinRule={room.getJoinRule()}
+                      roomType={room.getType()}
+                    />
+                  )}
+                </Avatar>
+                <Box as="span" grow="Yes">
+                  <Text
+                    priority={unread || hasRoomUnread || isActiveCall ? '500' : '300'}
+                    as="span"
+                    size="Inherit"
+                    truncate
+                  >
+                    {roomName}
+                  </Text>
+                </Box>
+                {!optionsVisible && !unread && !selected && typingMember.length > 0 && (
+                  <Badge size="300" variant="Secondary" fill="Soft" radii="Pill" outlined>
+                    <TypingIndicator size="300" disableAnimation />
+                  </Badge>
+                )}
+                {!optionsVisible && (unread || hasRoomUnread) && (
+                  <UnreadBadgeCenter>
+                    <UnreadBadge
+                      highlight={!!unread && unread.highlight > 0}
+                      count={unreadCount}
+                      dm={direct}
+                    />
+                  </UnreadBadgeCenter>
+                )}
+                {!optionsVisible && notificationMode !== RoomNotificationMode.Unset && (
+                  <Icon
+                    size="50"
+                    src={getRoomNotificationModeIcon(notificationMode)}
+                    aria-label={notificationMode}
                   />
                 )}
-              </Avatar>
-              <Box as="span" grow="Yes">
-                <Text
-                  priority={unread || hasRoomUnread || isActiveCall ? '500' : '300'}
-                  as="span"
-                  size="Inherit"
-                  truncate
-                >
-                  {roomName}
-                </Text>
               </Box>
-              {!optionsVisible && !unread && !selected && typingMember.length > 0 && (
-                <Badge size="300" variant="Secondary" fill="Soft" radii="Pill" outlined>
-                  <TypingIndicator size="300" disableAnimation />
-                </Badge>
-              )}
-              {!optionsVisible && (unread || hasRoomUnread) && (
-                <UnreadBadgeCenter>
-                  <UnreadBadge
-                    highlight={!!unread && unread.highlight > 0}
-                    count={unreadCount}
-                    dm={direct}
-                  />
-                </UnreadBadgeCenter>
-              )}
-              {!optionsVisible && notificationMode !== RoomNotificationMode.Unset && (
-                <Icon
-                  size="50"
-                  src={getRoomNotificationModeIcon(notificationMode)}
-                  aria-label={notificationMode}
-                />
-              )}
-            </Box>
-          </NavItemContent>
-        </NavButton>
-        {optionsVisible && (
-          <NavItemOptions>
-            <PopOut
-              id={`menu-${room.roomId}`}
-              aria-expanded={!!menuAnchor}
-              anchor={menuAnchor}
-              offset={menuAnchor?.width === 0 ? 0 : undefined}
-              alignOffset={menuAnchor?.width === 0 ? 0 : -5}
-              position="Bottom"
-              align={menuAnchor?.width === 0 ? 'Start' : 'End'}
-              content={
-                <FocusTrap
-                  focusTrapOptions={{
-                    initialFocus: false,
-                    returnFocusOnDeactivate: false,
-                    onDeactivate: () => setMenuAnchor(undefined),
-                    clickOutsideDeactivates: true,
-                    isKeyForward: (evt: KeyboardEvent) => evt.key === 'ArrowDown',
-                    isKeyBackward: (evt: KeyboardEvent) => evt.key === 'ArrowUp',
-                    escapeDeactivates: stopPropagation,
-                  }}
-                >
-                  <RoomNavItemMenu
-                    room={room}
-                    requestClose={() => setMenuAnchor(undefined)}
-                    notificationMode={notificationMode}
-                  />
-                </FocusTrap>
-              }
-            >
-              {room.isCallRoom() && (
-                <TooltipProvider
-                  position="Bottom"
-                  offset={4}
-                  tooltip={
-                    <Tooltip>
-                      <Text>{isChatOpen ? 'Hide Chat' : 'Show Chat'}</Text>
-                    </Tooltip>
-                  }
-                >
-                  {(triggerRef) => (
-                    <IconButton
-                      ref={triggerRef}
-                      data-testid="chat-button"
-                      onClick={handleChatButtonClick}
-                      aria-pressed={isChatOpen && selected}
-                      aria-label="Open Chat"
-                      variant="Background"
-                      fill="None"
-                      size="300"
-                      radii="300"
-                    >
-                      <Icon size="50" src={Icons.Message} />
-                    </IconButton>
-                  )}
-                </TooltipProvider>
-              )}
-              <IconButton
-                onClick={handleOpenMenu}
-                aria-pressed={!!menuAnchor}
-                aria-controls={`menu-${room.roomId}`}
-                aria-label="More Options"
-                variant="Background"
-                fill="None"
-                size="300"
-                radii="300"
+            </NavItemContent>
+          </NavButton>
+          {optionsVisible && (
+            <NavItemOptions>
+              <PopOut
+                id={`menu-${room.roomId}`}
+                aria-expanded={!!menuAnchor}
+                anchor={menuAnchor}
+                offset={menuAnchor?.width === 0 ? 0 : undefined}
+                alignOffset={menuAnchor?.width === 0 ? 0 : -5}
+                position="Bottom"
+                align={menuAnchor?.width === 0 ? 'Start' : 'End'}
+                content={
+                  <FocusTrap
+                    focusTrapOptions={{
+                      initialFocus: false,
+                      returnFocusOnDeactivate: false,
+                      onDeactivate: () => setMenuAnchor(undefined),
+                      clickOutsideDeactivates: true,
+                      isKeyForward: (evt: KeyboardEvent) => evt.key === 'ArrowDown',
+                      isKeyBackward: (evt: KeyboardEvent) => evt.key === 'ArrowUp',
+                      escapeDeactivates: stopPropagation,
+                    }}
+                  >
+                    <RoomNavItemMenu
+                      room={room}
+                      requestClose={() => setMenuAnchor(undefined)}
+                      notificationMode={notificationMode}
+                    />
+                  </FocusTrap>
+                }
               >
-                <Icon size="50" src={Icons.VerticalDots} />
-              </IconButton>
-            </PopOut>
-          </NavItemOptions>
+                {room.isCallRoom() && (
+                  <TooltipProvider
+                    position="Bottom"
+                    offset={4}
+                    tooltip={
+                      <Tooltip>
+                        <Text>{isChatOpen ? 'Hide Chat' : 'Show Chat'}</Text>
+                      </Tooltip>
+                    }
+                  >
+                    {(triggerRef) => (
+                      <IconButton
+                        ref={triggerRef}
+                        data-testid="chat-button"
+                        onClick={handleChatButtonClick}
+                        aria-pressed={isChatOpen && selected}
+                        aria-label="Open Chat"
+                        variant="Background"
+                        fill="None"
+                        size="300"
+                        radii="300"
+                      >
+                        <Icon size="50" src={Icons.Message} />
+                      </IconButton>
+                    )}
+                  </TooltipProvider>
+                )}
+                <IconButton
+                  onClick={handleOpenMenu}
+                  aria-pressed={!!menuAnchor}
+                  aria-controls={`menu-${room.roomId}`}
+                  aria-label="More Options"
+                  variant="Background"
+                  fill="None"
+                  size="300"
+                  radii="300"
+                >
+                  <Icon size="50" src={Icons.VerticalDots} />
+                </IconButton>
+              </PopOut>
+            </NavItemOptions>
+          )}
+        </NavItem>
+        {room.isCallRoom() && (
+          <Box direction="Column" style={{ paddingLeft: config.space.S200 }}>
+            {callMemberships.map((callMembership) => (
+              <RoomNavUser
+                key={callMembership.membershipID}
+                room={room}
+                callMembership={callMembership}
+              />
+            ))}
+          </Box>
         )}
-      </NavItem>
-      {room.isCallRoom() && (
-        <Box direction="Column" style={{ paddingLeft: config.space.S200 }}>
-          {callMemberships.map((callMembership) => (
-            <RoomNavUser
-              key={callMembership.membershipID}
-              room={room}
-              callMembership={callMembership}
-            />
-          ))}
-        </Box>
-      )}
-    </Box>
-  );
-}
+      </Box>
+    );
+  }
+);

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -705,6 +705,16 @@ export function RoomTimeline({
   //     (it always coincides with a setTimeline update which already re-renders)
   //   • the ResizeObserver closure can read it without stale-capture problems
   const isSettlingRef = useRef(true);
+  // Always-fresh reference to the current linkedTimelines array.
+  // Used by useLiveTimelineRefresh to detect live-TL replacement without
+  // listing the full array as a useCallback dep (which would re-register
+  // the EventEmitter listener on every render).
+  const linkedTimelinesRef = useRef<EventTimeline[]>([]);
+  // Stores the back-anchor DOM element so that observeBackAnchor can be
+  // called with the real element once settling completes. React only calls
+  // ref callbacks on mount/unmount or identity change; since settledObserveBackAnchor
+  // is stable and the element stays mounted, we need to re-register manually.
+  const backAnchorElementRef = useRef<HTMLElement | null>(null);
 
   const linkifyOpts = useMemo<LinkifyOpts>(
     () => ({
@@ -738,6 +748,7 @@ export function RoomTimeline({
     eventId ? getEmptyTimeline() : getInitialTimeline(room)
   );
   const eventsLength = getTimelinesEventsCount(timeline.linkedTimelines);
+  linkedTimelinesRef.current = timeline.linkedTimelines;
   const liveTimelineLinked =
     timeline.linkedTimelines[timeline.linkedTimelines.length - 1] === getLiveTimeline(room);
   const canPaginateBack =
@@ -908,45 +919,42 @@ export function RoomTimeline({
     useCallback(() => {
       // Use the always-fresh ref so this callback never captures a stale
       // linkedTimelines snapshot and never needs to be re-registered due to
-      // timeline state changes. Re-registering the listener on every render
-      // has two costs: (a) the old listener is torn down and the new one is
-      // set up between renders, creating a brief window where a TimelineRefresh
-      // could be missed; (b) React's closure captures a stale liveTimelineLinked
-      // value, causing the wrong branch to execute.
+      // timeline state changes.
       const currentLinkedTimelines = linkedTimelinesRef.current;
       const currentLive = getLiveTimeline(room);
       const ourLast = currentLinkedTimelines[currentLinkedTimelines.length - 1];
       const liveTimelineReplaced = ourLast !== undefined && ourLast !== currentLive;
 
+      // Capture before clearing — wasSettling = true on the first subscription
+      // response. We must scroll to bottom unconditionally on initial load
+      // (atLiveEndRef may be stale if an intermediate render updated
+      // linkedTimelinesRef before this callback ran).
+      const wasSettling = isSettlingRef.current;
+      isSettlingRef.current = false;
+      // Re-register the back anchor now that settling is complete.
+      // The ref callback is stable so React won't re-call it; we do it manually.
+      observeBackAnchor(backAnchorElementRef.current);
+
       if (liveTimelineReplaced || currentLinkedTimelines.length === 0) {
-        // Initial subscription landing or empty timeline: reset to the full
-        // event window and scroll to the live end.
-        // We never auto-scroll to the unread position here — the user always
-        // lands at the bottom; "Jump to Unread" is the explicit navigation.
-        // We do re-evaluate unreadInfo so the divider renders at the correct
-        // position now that the subscription has delivered the full event set
-        // (the mount-time 5-event cache may not have had the read marker).
+        // Initial subscription landing or reset: rebuild the range from the new
+        // live timeline and scroll to the live end.
         setTimeline(getInitialTimeline(room));
-        isSettlingRef.current = false;
         const freshUnread = getRoomUnreadInfo(room);
         if (freshUnread) setUnreadInfo({ ...freshUnread, scrollTo: false });
         scrollToBottomRef.current.count += 1;
         scrollToBottomRef.current.smooth = false;
-      } else if (atLiveEndRef.current) {
-        // User is at the live end — safe to reset the range so new limited=true
-        // events are included in the window. Also trigger a bottom scroll so
-        // the user isn't left stranded above the newly-appended events.
+      } else if (wasSettling || atLiveEndRef.current) {
+        // wasSettling: first subscription response on a non-replaced timeline
+        //   (limited=false path, or intermediate render already advanced the ref)
+        //   — always land at the bottom on initial open.
+        // atLiveEndRef: user is at the live end during a subsequent refresh
+        //   — follow new events down.
         setTimeline(getInitialTimeline(room));
-        // Subscription has responded — clear the settling flag so the
-        // ResizeObserver forceScroll can maintain bottom position as images load.
-        isSettlingRef.current = false;
         scrollToBottomRef.current.count += 1;
         scrollToBottomRef.current.smooth = false;
       }
-      // !atLiveEndRef.current: user has scrolled up into history.
-      // Do nothing — preserve their scroll position. The new events
-      // will become visible when they next scroll to the live end.
-    }, [room]) // linkedTimelinesRef and atLiveEndRef are refs — stable, no dep needed
+      // else: user has scrolled up into history — preserve their position.
+    }, [room, observeBackAnchor]) // backAnchorElementRef is a ref — stable, no dep needed
   );
 
   // Safety net for non-limited subscription responses (limited=false): the SDK
@@ -956,9 +964,11 @@ export function RoomTimeline({
   useSubscriptionBackfill(
     room,
     useCallback(() => {
-      // Non-limited response has settled — stop suppressing the back-pagination
-      // indicator now that real events are present.
+      // Non-limited response has settled.
+      const wasSettling = isSettlingRef.current;
       isSettlingRef.current = false;
+      // Re-register back anchor now that settling is done.
+      observeBackAnchor(backAnchorElementRef.current);
       setTimeline((ct) => {
         const newEnd = getTimelinesEventsCount(ct.linkedTimelines);
         if (newEnd <= ct.range.end) return ct; // no growth, nothing to do
@@ -970,12 +980,13 @@ export function RoomTimeline({
           },
         };
       });
-      // If the user was scrolled to the bottom before backfill, keep them there.
-      if (atBottomRef.current) {
+      // Always scroll to bottom on the initial room open (wasSettling).
+      // After that, only follow if the user was already at the bottom.
+      if (wasSettling || atBottomRef.current) {
         scrollToBottomRef.current.count += 1;
         scrollToBottomRef.current.smooth = false;
       }
-    }, []) // setTimeline is a stable setter, intentionally omitted
+    }, [observeBackAnchor]) // setTimeline/atBottomRef are stable; backAnchorElementRef is a ref
   );
 
   // Re-render when non-live Replace relations arrive (bundled/historical edits
@@ -2144,12 +2155,14 @@ export function RoomTimeline({
   };
 
   // During the initial settling window (before the subscription delivers its
-  // first batch), suppress the back-anchor observer so it doesn't trigger a
-  // backward pagination on the single list-preview event. Once the subscription
-  // lands (isSettlingRef.current = false) the null→real-ref swap causes the
-  // IntersectionObserver to observe the anchor and back-pagination works normally.
+  // first batch), suppress the back-anchor observer so it doesn't trigger
+  // backward pagination prematurely. We store the element in backAnchorElementRef
+  // so that useLiveTimelineRefresh / useSubscriptionBackfill can re-register it
+  // with observeBackAnchor once settling is complete (the ref callback won't
+  // fire again since settledObserveBackAnchor's identity is stable).
   const settledObserveBackAnchor = useCallback<(el: HTMLElement | null) => void>(
     (el) => {
+      backAnchorElementRef.current = el;
       observeBackAnchor(isSettlingRef.current ? null : el);
     },
     [observeBackAnchor]

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -901,22 +901,14 @@ export function RoomTimeline({
           scrollToBottomRef.current.count += 1;
           scrollToBottomRef.current.smooth = false;
         }
-      } else if (liveTimelineLinked) {
-        if (atLiveEndRef.current) {
-          // User is at the live end — safe to reset the range so new events
-          // delivered with limited=true are included.
-          setTimeline(getInitialTimeline(room));
-        } else {
-          // User has scrolled up into history while still on the live
-          // timeline. A limited=true batch arrived but we must NOT jump the
-          // viewport. Only refresh the linkedTimelines reference so backward
-          // pagination stays coherent; the visible range is preserved.
-          setTimeline((ct) => ({
-            ...ct,
-            linkedTimelines: getLinkedTimelines(currentLive),
-          }));
-        }
+      } else if (liveTimelineLinked && atLiveEndRef.current) {
+        // User is at the live end — safe to reset the range so new limited=true
+        // events are included in the window.
+        setTimeline(getInitialTimeline(room));
       }
+      // liveTimelineLinked && !atLiveEndRef.current: user has scrolled up into
+      // history. Do nothing — preserve their scroll position. The new events
+      // will become visible when they next scroll to the live end.
     }, [room, liveTimelineLinked, timeline.linkedTimelines, unreadInfo])
   );
 
@@ -2081,10 +2073,7 @@ export function RoomTimeline({
   };
 
   let backPaginationJSX: ReactNode | undefined;
-  // Suppress all back-pagination UI while the initial subscription response
-  // hasn't arrived yet. This prevents the loading spinner and skeleton
-  // placeholders from flashing in before any real messages are rendered.
-  if (!isSettling && (canPaginateBack || !rangeAtStart || backwardStatus !== 'idle')) {
+  if (canPaginateBack || !rangeAtStart || backwardStatus !== 'idle') {
     if (backwardStatus === 'error') {
       backPaginationJSX = (
         <Box

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -587,13 +587,19 @@ const getRoomUnreadInfo = (room: Room, scrollTo = false) => {
 
   // inLiveTimeline = true only when ALL of these hold:
   //   1. The read-upto event is in the current live timeline (not a paginated predecessor).
-  //   2. There is at least one event AFTER it in the live timeline (i.e. actual unread
-  //      content exists to scroll to). If the readUpto event is the last event we should
-  //      land at the bottom, not position the last-read message at the top of the viewport.
-  // Stale server notification counts can cause roomHaveNotification=true even when the
-  // user has read everything, so we must not rely solely on that signal.
+  //   2. There is at least one event AFTER it in the live timeline (events to scroll to).
+  //   3. roomHaveUnread confirms there is a genuine unread notification event between
+  //      the readUptoEventId and the end of the live timeline. This is the critical guard
+  //      against stale server notification counts (roomHaveNotification can be non-zero
+  //      even when the user has read everything). roomHaveUnread walks live timeline events
+  //      newest-first and returns true only if it finds a notification event before hitting
+  //      the readUpToId — meaning there is something the user actually hasn't seen.
   let inLiveTimeline = false;
-  if (evtTimeline !== undefined && evtTimeline === liveTimeline) {
+  if (
+    evtTimeline !== undefined &&
+    evtTimeline === liveTimeline &&
+    roomHaveUnread(room.client, room)
+  ) {
     const liveEvents = liveTimeline.getEvents();
     const readIdx = liveEvents.findIndex((e) => e.getId() === readUptoEventId);
     inLiveTimeline = readIdx >= 0 && readIdx < liveEvents.length - 1;

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -438,10 +438,12 @@ const useTimelinePagination = (
 
 const useLiveEventArrive = (room: Room, onArrive: (mEvent: MatrixEvent) => void) => {
   useEffect(() => {
-    // Capture the live timeline and registration time. Events appended to the
-    // live timeline AFTER this point can be genuinely new even when
-    // liveEvent=false (older sliding sync proxies that omit num_live).
-    const liveTimeline = getLiveTimeline(room);
+    // Capture the registration time. Events appended to the live timeline AFTER
+    // this point can be genuinely new even when liveEvent=false (older sliding
+    // sync proxies that omit num_live).
+    // NOTE: we intentionally do NOT capture liveTimeline here — after a
+    // TimelineRefresh the SDK replaces the live timeline object, so we must
+    // call getLiveTimeline(room) at handler invocation time to stay current.
     const registeredAt = Date.now();
     const handleTimelineEvent: EventTimelineSetHandlerMap[RoomEvent.Timeline] = (
       mEvent: MatrixEvent,
@@ -460,7 +462,7 @@ const useLiveEventArrive = (room: Room, onArrive: (mEvent: MatrixEvent) => void)
         data.liveEvent ||
         (!toStartOfTimeline &&
           !removed &&
-          data.timeline === liveTimeline &&
+          data.timeline === getLiveTimeline(room) &&
           mEvent.getTs() >= registeredAt - 60_000);
       if (!isLive) return;
       onArrive(mEvent);
@@ -506,15 +508,53 @@ const useRelationUpdate = (room: Room, onRelation: () => void) => {
   }, [room, onRelation]);
 };
 
+// Detects subscription backfill on the live timeline that does NOT trigger a
+// TimelineRefresh (i.e. limited=false responses). Triggers a lightweight
+// re-render so useVirtualPaginator picks up the updated event count and so that
+// the "stuck on old range" safety effect can recalibrate.
+const useSubscriptionBackfill = (room: Room, onBackfill: () => void) => {
+  useEffect(() => {
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    const handleTimelineEvent: EventTimelineSetHandlerMap[RoomEvent.Timeline] = (
+      _mEvent: MatrixEvent,
+      eventRoom: Room | undefined,
+      toStartOfTimeline: boolean | undefined,
+      removed: boolean,
+      data: IRoomTimelineData
+    ) => {
+      // Ignore already-handled live events and backward-paginated events.
+      if (eventRoom?.roomId !== room.roomId) return;
+      if (data.liveEvent || toStartOfTimeline || removed) return;
+      // This is a non-live forward event (subscription backfill).
+      // Debounce to batch multiple events in the same response into one render.
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => onBackfill(), 0);
+    };
+
+    room.on(RoomEvent.Timeline, handleTimelineEvent);
+    return () => {
+      clearTimeout(debounceTimer);
+      room.removeListener(RoomEvent.Timeline, handleTimelineEvent);
+    };
+  }, [room, onBackfill]);
+};
+
 const useLiveTimelineRefresh = (room: Room, onRefresh: () => void) => {
   useEffect(() => {
+    let cancelled = false;
     const handleTimelineRefresh: RoomEventHandlerMap[RoomEvent.TimelineRefresh] = (r: Room) => {
       if (r.roomId !== room.roomId) return;
-      onRefresh();
+      // Defer one tick: the SDK fires TimelineRefresh before adding subscription
+      // events to the new live timeline. Running after the current synchronous
+      // batch ensures getInitialTimeline() captures all delivered events.
+      setTimeout(() => {
+        if (!cancelled) onRefresh();
+      }, 0);
     };
 
     room.on(RoomEvent.TimelineRefresh, handleTimelineRefresh);
     return () => {
+      cancelled = true;
       room.removeListener(RoomEvent.TimelineRefresh, handleTimelineRefresh);
     };
   }, [room, onRefresh]);
@@ -834,10 +874,49 @@ export function RoomTimeline({
   useLiveTimelineRefresh(
     room,
     useCallback(() => {
-      if (liveTimelineLinked || timeline.linkedTimelines.length === 0) {
+      // liveTimelineLinked becomes false after a TimelineRefresh because our
+      // stored linkedTimelines still reference the OLD live timeline while the
+      // SDK has already created a new one (e.g. setActiveRoom subscription fires
+      // with limited=true). Detect this explicitly so the refresh always runs.
+      const currentLive = getLiveTimeline(room);
+      const ourLast = timeline.linkedTimelines[timeline.linkedTimelines.length - 1];
+      const liveTimelineReplaced = ourLast !== undefined && ourLast !== currentLive;
+      if (liveTimelineLinked || timeline.linkedTimelines.length === 0 || liveTimelineReplaced) {
         setTimeline(getInitialTimeline(room));
+        // Scroll to bottom when the live timeline was replaced (initial
+        // subscription load) so the user lands on the latest messages.
+        if (liveTimelineReplaced) {
+          scrollToBottomRef.current.count += 1;
+          scrollToBottomRef.current.smooth = false;
+        }
       }
-    }, [room, liveTimelineLinked, timeline.linkedTimelines.length])
+    }, [room, liveTimelineLinked, timeline.linkedTimelines])
+  );
+
+  // Safety net for non-limited subscription responses (limited=false): the SDK
+  // appends events to the existing live timeline without firing TimelineRefresh,
+  // so the component's stored range never learns about the new events. When
+  // backfill is detected, re-anchor the range to the SDK's true end.
+  useSubscriptionBackfill(
+    room,
+    useCallback(() => {
+      setTimeline((ct) => {
+        const newEnd = getTimelinesEventsCount(ct.linkedTimelines);
+        if (newEnd <= ct.range.end) return ct; // no growth, nothing to do
+        return {
+          ...ct,
+          range: {
+            start: Math.max(newEnd - PAGINATION_LIMIT, 0),
+            end: newEnd,
+          },
+        };
+      });
+      // If the user was scrolled to the bottom before backfill, keep them there.
+      if (atBottomRef.current) {
+        scrollToBottomRef.current.count += 1;
+        scrollToBottomRef.current.smooth = false;
+      }
+    }, [])
   );
 
   // Re-render when non-live Replace relations arrive (bundled/historical edits

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -582,15 +582,26 @@ const getRoomUnreadInfo = (room: Room, scrollTo = false) => {
 
   const readUptoEventId = room.getEventReadUpTo(room.client.getUserId() ?? '');
   if (!readUptoEventId) return undefined;
+  const liveTimeline = getLiveTimeline(room);
   const evtTimeline = getEventTimeline(room, readUptoEventId);
-  // inLiveTimeline = true only when the read-upto event is literally inside the
-  // current live timeline object (not merely connected to it via the paginated
-  // chain). If the event lives in an older linked timeline we treat it as stale
-  // and fall back to scroll-to-bottom, which avoids landing partway up history
-  // when the room has stale server notification counts or an old read receipt.
+
+  // inLiveTimeline = true only when ALL of these hold:
+  //   1. The read-upto event is in the current live timeline (not a paginated predecessor).
+  //   2. There is at least one event AFTER it in the live timeline (i.e. actual unread
+  //      content exists to scroll to). If the readUpto event is the last event we should
+  //      land at the bottom, not position the last-read message at the top of the viewport.
+  // Stale server notification counts can cause roomHaveNotification=true even when the
+  // user has read everything, so we must not rely solely on that signal.
+  let inLiveTimeline = false;
+  if (evtTimeline !== undefined && evtTimeline === liveTimeline) {
+    const liveEvents = liveTimeline.getEvents();
+    const readIdx = liveEvents.findIndex((e) => e.getId() === readUptoEventId);
+    inLiveTimeline = readIdx >= 0 && readIdx < liveEvents.length - 1;
+  }
+
   return {
     readUptoEventId,
-    inLiveTimeline: evtTimeline !== undefined && evtTimeline === getLiveTimeline(room),
+    inLiveTimeline,
     scrollTo,
   };
 };

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -583,10 +583,14 @@ const getRoomUnreadInfo = (room: Room, scrollTo = false) => {
   const readUptoEventId = room.getEventReadUpTo(room.client.getUserId() ?? '');
   if (!readUptoEventId) return undefined;
   const evtTimeline = getEventTimeline(room, readUptoEventId);
-  const latestTimeline = evtTimeline && getFirstLinkedTimeline(evtTimeline, Direction.Forward);
+  // inLiveTimeline = true only when the read-upto event is literally inside the
+  // current live timeline object (not merely connected to it via the paginated
+  // chain). If the event lives in an older linked timeline we treat it as stale
+  // and fall back to scroll-to-bottom, which avoids landing partway up history
+  // when the room has stale server notification counts or an old read receipt.
   return {
     readUptoEventId,
-    inLiveTimeline: latestTimeline === room.getLiveTimeline(),
+    inLiveTimeline: evtTimeline !== undefined && evtTimeline === getLiveTimeline(room),
     scrollTo,
   };
 };

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -906,15 +906,19 @@ export function RoomTimeline({
   useLiveTimelineRefresh(
     room,
     useCallback(() => {
-      // liveTimelineLinked becomes false after a TimelineRefresh because our
-      // stored linkedTimelines still reference the OLD live timeline while the
-      // SDK has already created a new one (e.g. setActiveRoom subscription fires
-      // with limited=true). Detect this explicitly so the refresh always runs.
+      // Use the always-fresh ref so this callback never captures a stale
+      // linkedTimelines snapshot and never needs to be re-registered due to
+      // timeline state changes. Re-registering the listener on every render
+      // has two costs: (a) the old listener is torn down and the new one is
+      // set up between renders, creating a brief window where a TimelineRefresh
+      // could be missed; (b) React's closure captures a stale liveTimelineLinked
+      // value, causing the wrong branch to execute.
+      const currentLinkedTimelines = linkedTimelinesRef.current;
       const currentLive = getLiveTimeline(room);
-      const ourLast = timeline.linkedTimelines[timeline.linkedTimelines.length - 1];
+      const ourLast = currentLinkedTimelines[currentLinkedTimelines.length - 1];
       const liveTimelineReplaced = ourLast !== undefined && ourLast !== currentLive;
 
-      if (liveTimelineReplaced || timeline.linkedTimelines.length === 0) {
+      if (liveTimelineReplaced || currentLinkedTimelines.length === 0) {
         // Initial subscription landing or empty timeline: reset to the full
         // event window and scroll to the live end.
         // We never auto-scroll to the unread position here — the user always
@@ -928,7 +932,7 @@ export function RoomTimeline({
         if (freshUnread) setUnreadInfo({ ...freshUnread, scrollTo: false });
         scrollToBottomRef.current.count += 1;
         scrollToBottomRef.current.smooth = false;
-      } else if (liveTimelineLinked && atLiveEndRef.current) {
+      } else if (atLiveEndRef.current) {
         // User is at the live end — safe to reset the range so new limited=true
         // events are included in the window. Also trigger a bottom scroll so
         // the user isn't left stranded above the newly-appended events.
@@ -939,10 +943,10 @@ export function RoomTimeline({
         scrollToBottomRef.current.count += 1;
         scrollToBottomRef.current.smooth = false;
       }
-      // liveTimelineLinked && !atLiveEndRef.current: user has scrolled up into
-      // history. Do nothing — preserve their scroll position. The new events
+      // !atLiveEndRef.current: user has scrolled up into history.
+      // Do nothing — preserve their scroll position. The new events
       // will become visible when they next scroll to the live end.
-    }, [room, liveTimelineLinked, timeline.linkedTimelines])
+    }, [room]) // linkedTimelinesRef and atLiveEndRef are refs — stable, no dep needed
   );
 
   // Safety net for non-limited subscription responses (limited=false): the SDK
@@ -2139,6 +2143,18 @@ export function RoomTimeline({
     return eventJSX;
   };
 
+  // During the initial settling window (before the subscription delivers its
+  // first batch), suppress the back-anchor observer so it doesn't trigger a
+  // backward pagination on the single list-preview event. Once the subscription
+  // lands (isSettlingRef.current = false) the null→real-ref swap causes the
+  // IntersectionObserver to observe the anchor and back-pagination works normally.
+  const settledObserveBackAnchor = useCallback<(el: HTMLElement | null) => void>(
+    (el) => {
+      observeBackAnchor(isSettlingRef.current ? null : el);
+    },
+    [observeBackAnchor]
+  );
+
   let backPaginationJSX: ReactNode | undefined;
   if (canPaginateBack || !rangeAtStart || backwardStatus !== 'idle') {
     if (backwardStatus === 'error') {
@@ -2184,7 +2200,7 @@ export function RoomTimeline({
             <MessageBase>
               <CompactPlaceholder />
             </MessageBase>
-            <MessageBase ref={observeBackAnchor}>
+            <MessageBase ref={settledObserveBackAnchor}>
               <CompactPlaceholder />
             </MessageBase>
           </>
@@ -2196,13 +2212,13 @@ export function RoomTimeline({
             <MessageBase>
               <DefaultPlaceholder />
             </MessageBase>
-            <MessageBase ref={observeBackAnchor}>
+            <MessageBase ref={settledObserveBackAnchor}>
               <DefaultPlaceholder />
             </MessageBase>
           </>
         );
     } else {
-      backPaginationJSX = <div ref={observeBackAnchor} style={{ height: 1 }} />;
+      backPaginationJSX = <div ref={settledObserveBackAnchor} style={{ height: 1 }} />;
     }
   }
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -668,7 +668,10 @@ export function RoomTimeline({
 
   const imagePackRooms: Room[] = useImagePackRooms(room.roomId, roomToParents);
 
-  const [unreadInfo, setUnreadInfo] = useState(() => getRoomUnreadInfo(room, true));
+  // scrollTo=false: we never auto-scroll to the unread position on open — the
+  // user always lands at the live end and uses "Jump to Unread" to navigate.
+  // inLiveTimeline/readUptoEventId are still set so the unread divider renders.
+  const [unreadInfo, setUnreadInfo] = useState(() => getRoomUnreadInfo(room, false));
   const readUptoEventIdRef = useRef<string>();
   if (unreadInfo) {
     readUptoEventIdRef.current = unreadInfo.readUptoEventId;
@@ -912,28 +915,27 @@ export function RoomTimeline({
       const liveTimelineReplaced = ourLast !== undefined && ourLast !== currentLive;
 
       if (liveTimelineReplaced || timeline.linkedTimelines.length === 0) {
-        // Initial subscription landing or empty timeline: always reset and
-        // pick the correct scroll target.
+        // Initial subscription landing or empty timeline: reset to the full
+        // event window and scroll to the live end.
+        // We never auto-scroll to the unread position here — the user always
+        // lands at the bottom; "Jump to Unread" is the explicit navigation.
+        // We do re-evaluate unreadInfo so the divider renders at the correct
+        // position now that the subscription has delivered the full event set
+        // (the mount-time 5-event cache may not have had the read marker).
         setTimeline(getInitialTimeline(room));
         isSettlingRef.current = false;
-        // Re-evaluate unread state NOW, after the subscription has delivered
-        // events into the timeline. At mount time the readUptoEventId may not
-        // have been present in any local timeline (cold cache / clear cache),
-        // causing the initialised unreadInfo to have inLiveTimeline=false even
-        // when the user does have unreads. Using the closed-over stale value
-        // would scroll to bottom instead of to the unread position.
         const freshUnread = getRoomUnreadInfo(room);
-        if (freshUnread?.inLiveTimeline) {
-          setUnreadInfo({ ...freshUnread, scrollTo: true });
-        } else {
-          scrollToBottomRef.current.count += 1;
-          scrollToBottomRef.current.smooth = false;
-        }
+        if (freshUnread) setUnreadInfo({ ...freshUnread, scrollTo: false });
+        scrollToBottomRef.current.count += 1;
+        scrollToBottomRef.current.smooth = false;
       } else if (liveTimelineLinked && atLiveEndRef.current) {
         // User is at the live end — safe to reset the range so new limited=true
         // events are included in the window. Also trigger a bottom scroll so
         // the user isn't left stranded above the newly-appended events.
         setTimeline(getInitialTimeline(room));
+        // Subscription has responded — clear the settling flag so the
+        // ResizeObserver forceScroll can maintain bottom position as images load.
+        isSettlingRef.current = false;
         scrollToBottomRef.current.count += 1;
         scrollToBottomRef.current.smooth = false;
       }
@@ -989,6 +991,26 @@ export function RoomTimeline({
     if (getLiveTimeline(room).getEvents().length === 0) return;
     setTimeline(getInitialTimeline(room));
   }, [eventId, room, timeline.linkedTimelines.length]);
+
+  // Safety net: if the subscription never fires TimelineRefresh or backfill
+  // (e.g. a fully-synced room with no new events), isSettlingRef would stay
+  // true indefinitely, permanently suppressing the ResizeObserver forceScroll
+  // that keeps the view pinned to the bottom as images load.
+  // After a short grace period, force-clear settling so image loads are handled.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (!eventId) {
+      timer = setTimeout(() => {
+        if (!isSettlingRef.current) return;
+        isSettlingRef.current = false;
+        const scrollEl = scrollRef.current;
+        if (scrollEl && atBottomRef.current) {
+          scrollToBottom(scrollEl, 'instant');
+        }
+      }, 500);
+    }
+    return () => clearTimeout(timer);
+  }, [room, eventId]);
 
   // Stay at bottom when room editor resize
   useResizeObserver(
@@ -1146,14 +1168,24 @@ export function RoomTimeline({
       }
     };
 
+    // Cancel-and-reschedule pattern: a burst of rapid resizes (e.g. many
+    // encrypted messages decrypting in sequence) will be collapsed into a
+    // single forceScroll call once the burst settles, eliminating the
+    // rapid scroll-up / snap-to-bottom flicker visible during initial decrypt.
+    let pendingRaf: ReturnType<typeof requestAnimationFrame> | undefined;
     const resizeObserver = new ResizeObserver(() => {
-      requestAnimationFrame(forceScroll);
+      if (pendingRaf !== undefined) cancelAnimationFrame(pendingRaf);
+      pendingRaf = requestAnimationFrame(() => {
+        pendingRaf = undefined;
+        forceScroll();
+      });
     });
 
     scrollEl.addEventListener('scroll', handleScroll, { passive: true });
     resizeObserver.observe(contentEl);
 
     return () => {
+      if (pendingRaf !== undefined) cancelAnimationFrame(pendingRaf);
       resizeObserver.disconnect();
       scrollEl.removeEventListener('scroll', handleScroll);
     };

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -676,10 +676,11 @@ export function RoomTimeline({
 
   // True from mount until the first subscription response settles (either a
   // TimelineRefresh for limited responses, or the first backfill batch for
-  // non-limited responses). Used to suppress the backward-pagination spinner
-  // and placeholder skeletons that would otherwise flash before real content
-  // arrives.
-  const [isSettling, setIsSettling] = useState(true);
+  // non-limited responses). Stored as a ref (not state) so that:
+  //   • the transition to false does not cause an extra render cycle on its own
+  //     (it always coincides with a setTimeline update which already re-renders)
+  //   • the ResizeObserver closure can read it without stale-capture problems
+  const isSettlingRef = useRef(true);
 
   const linkifyOpts = useMemo<LinkifyOpts>(
     () => ({
@@ -893,7 +894,7 @@ export function RoomTimeline({
         // Initial subscription landing or empty timeline: always reset and
         // pick the correct scroll target.
         setTimeline(getInitialTimeline(room));
-        setIsSettling(false);
+        isSettlingRef.current = false;
         if (unreadInfo?.inLiveTimeline) {
           // Re-trigger unread scroll so it fires against the full timeline.
           setUnreadInfo((cur) => (cur ? { ...cur, scrollTo: true } : cur));
@@ -903,8 +904,11 @@ export function RoomTimeline({
         }
       } else if (liveTimelineLinked && atLiveEndRef.current) {
         // User is at the live end — safe to reset the range so new limited=true
-        // events are included in the window.
+        // events are included in the window. Also trigger a bottom scroll so
+        // the user isn't left stranded above the newly-appended events.
         setTimeline(getInitialTimeline(room));
+        scrollToBottomRef.current.count += 1;
+        scrollToBottomRef.current.smooth = false;
       }
       // liveTimelineLinked && !atLiveEndRef.current: user has scrolled up into
       // history. Do nothing — preserve their scroll position. The new events
@@ -921,7 +925,7 @@ export function RoomTimeline({
     useCallback(() => {
       // Non-limited response has settled — stop suppressing the back-pagination
       // indicator now that real events are present.
-      setIsSettling(false);
+      isSettlingRef.current = false;
       setTimeline((ct) => {
         const newEnd = getTimelinesEventsCount(ct.linkedTimelines);
         if (newEnd <= ct.range.end) return ct; // no growth, nothing to do
@@ -938,7 +942,7 @@ export function RoomTimeline({
         scrollToBottomRef.current.count += 1;
         scrollToBottomRef.current.smooth = false;
       }
-    }, []) // setIsSettling is a stable setter, intentionally omitted
+    }, []) // setTimeline is a stable setter, intentionally omitted
   );
 
   // Re-render when non-live Replace relations arrive (bundled/historical edits
@@ -1105,6 +1109,10 @@ export function RoomTimeline({
     };
 
     const forceScroll = () => {
+      // Do not compete with the subscription-settle scroll during initial load.
+      // Once the first batch of events lands (isSettlingRef.current becomes false)
+      // the ResizeObserver may freely maintain scroll-to-bottom for image loads.
+      if (isSettlingRef.current) return;
       // if the user isn't scrolling jump down to latest content
       if (!userIsScrollingUp) {
         scrollToBottom(scrollEl, 'instant');
@@ -2168,7 +2176,7 @@ export function RoomTimeline({
           <Spinner variant="Secondary" size="400" />
         </Box>
       );
-    } else if (timelineItems.length === 0 && !isSettling) {
+    } else if (timelineItems.length === 0 && !isSettlingRef.current) {
       frontPaginationJSX =
         messageLayout === MessageLayout.Compact ? (
           <>

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -674,6 +674,13 @@ export function RoomTimeline({
   >();
   const alive = useAlive();
 
+  // True from mount until the first subscription response settles (either a
+  // TimelineRefresh for limited responses, or the first backfill batch for
+  // non-limited responses). Used to suppress the backward-pagination spinner
+  // and placeholder skeletons that would otherwise flash before real content
+  // arrives.
+  const [isSettling, setIsSettling] = useState(true);
+
   const linkifyOpts = useMemo<LinkifyOpts>(
     () => ({
       ...LINKIFY_OPTS,
@@ -883,14 +890,23 @@ export function RoomTimeline({
       const liveTimelineReplaced = ourLast !== undefined && ourLast !== currentLive;
       if (liveTimelineLinked || timeline.linkedTimelines.length === 0 || liveTimelineReplaced) {
         setTimeline(getInitialTimeline(room));
-        // Scroll to bottom when the live timeline was replaced (initial
-        // subscription load) so the user lands on the latest messages.
+        // Subscription has delivered its first batch — stop suppressing the
+        // backward-pagination indicator.
+        setIsSettling(false);
         if (liveTimelineReplaced) {
-          scrollToBottomRef.current.count += 1;
-          scrollToBottomRef.current.smooth = false;
+          if (unreadInfo?.inLiveTimeline) {
+            // Re-trigger unread scroll: the event is on the live timeline so
+            // it's now accessible in the full-events timeline.
+            setUnreadInfo((cur) => (cur ? { ...cur, scrollTo: true } : cur));
+          } else {
+            // No unread (or unread is in older paginated history) — land at
+            // the bottom so the user sees the latest messages.
+            scrollToBottomRef.current.count += 1;
+            scrollToBottomRef.current.smooth = false;
+          }
         }
       }
-    }, [room, liveTimelineLinked, timeline.linkedTimelines])
+    }, [room, liveTimelineLinked, timeline.linkedTimelines, unreadInfo])
   );
 
   // Safety net for non-limited subscription responses (limited=false): the SDK
@@ -900,6 +916,9 @@ export function RoomTimeline({
   useSubscriptionBackfill(
     room,
     useCallback(() => {
+      // Non-limited response has settled — stop suppressing the back-pagination
+      // indicator now that real events are present.
+      setIsSettling(false);
       setTimeline((ct) => {
         const newEnd = getTimelinesEventsCount(ct.linkedTimelines);
         if (newEnd <= ct.range.end) return ct; // no growth, nothing to do
@@ -916,7 +935,7 @@ export function RoomTimeline({
         scrollToBottomRef.current.count += 1;
         scrollToBottomRef.current.smooth = false;
       }
-    }, [])
+    }, []) // setIsSettling is a stable setter, intentionally omitted
   );
 
   // Re-render when non-live Replace relations arrive (bundled/historical edits
@@ -2051,7 +2070,10 @@ export function RoomTimeline({
   };
 
   let backPaginationJSX: ReactNode | undefined;
-  if (canPaginateBack || !rangeAtStart || backwardStatus !== 'idle') {
+  // Suppress all back-pagination UI while the initial subscription response
+  // hasn't arrived yet. This prevents the loading spinner and skeleton
+  // placeholders from flashing in before any real messages are rendered.
+  if (!isSettling && (canPaginateBack || !rangeAtStart || backwardStatus !== 'idle')) {
     if (backwardStatus === 'error') {
       backPaginationJSX = (
         <Box

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -888,22 +888,33 @@ export function RoomTimeline({
       const currentLive = getLiveTimeline(room);
       const ourLast = timeline.linkedTimelines[timeline.linkedTimelines.length - 1];
       const liveTimelineReplaced = ourLast !== undefined && ourLast !== currentLive;
-      if (liveTimelineLinked || timeline.linkedTimelines.length === 0 || liveTimelineReplaced) {
+
+      if (liveTimelineReplaced || timeline.linkedTimelines.length === 0) {
+        // Initial subscription landing or empty timeline: always reset and
+        // pick the correct scroll target.
         setTimeline(getInitialTimeline(room));
-        // Subscription has delivered its first batch — stop suppressing the
-        // backward-pagination indicator.
         setIsSettling(false);
-        if (liveTimelineReplaced) {
-          if (unreadInfo?.inLiveTimeline) {
-            // Re-trigger unread scroll: the event is on the live timeline so
-            // it's now accessible in the full-events timeline.
-            setUnreadInfo((cur) => (cur ? { ...cur, scrollTo: true } : cur));
-          } else {
-            // No unread (or unread is in older paginated history) — land at
-            // the bottom so the user sees the latest messages.
-            scrollToBottomRef.current.count += 1;
-            scrollToBottomRef.current.smooth = false;
-          }
+        if (unreadInfo?.inLiveTimeline) {
+          // Re-trigger unread scroll so it fires against the full timeline.
+          setUnreadInfo((cur) => (cur ? { ...cur, scrollTo: true } : cur));
+        } else {
+          scrollToBottomRef.current.count += 1;
+          scrollToBottomRef.current.smooth = false;
+        }
+      } else if (liveTimelineLinked) {
+        if (atLiveEndRef.current) {
+          // User is at the live end — safe to reset the range so new events
+          // delivered with limited=true are included.
+          setTimeline(getInitialTimeline(room));
+        } else {
+          // User has scrolled up into history while still on the live
+          // timeline. A limited=true batch arrived but we must NOT jump the
+          // viewport. Only refresh the linkedTimelines reference so backward
+          // pagination stays coherent; the visible range is preserved.
+          setTimeline((ct) => ({
+            ...ct,
+            linkedTimelines: getLinkedTimelines(currentLive),
+          }));
         }
       }
     }, [room, liveTimelineLinked, timeline.linkedTimelines, unreadInfo])
@@ -2168,7 +2179,7 @@ export function RoomTimeline({
           <Spinner variant="Secondary" size="400" />
         </Box>
       );
-    } else if (timelineItems.length === 0) {
+    } else if (timelineItems.length === 0 && !isSettling) {
       frontPaginationJSX =
         messageLayout === MessageLayout.Compact ? (
           <>

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -895,9 +895,15 @@ export function RoomTimeline({
         // pick the correct scroll target.
         setTimeline(getInitialTimeline(room));
         isSettlingRef.current = false;
-        if (unreadInfo?.inLiveTimeline) {
-          // Re-trigger unread scroll so it fires against the full timeline.
-          setUnreadInfo((cur) => (cur ? { ...cur, scrollTo: true } : cur));
+        // Re-evaluate unread state NOW, after the subscription has delivered
+        // events into the timeline. At mount time the readUptoEventId may not
+        // have been present in any local timeline (cold cache / clear cache),
+        // causing the initialised unreadInfo to have inLiveTimeline=false even
+        // when the user does have unreads. Using the closed-over stale value
+        // would scroll to bottom instead of to the unread position.
+        const freshUnread = getRoomUnreadInfo(room);
+        if (freshUnread?.inLiveTimeline) {
+          setUnreadInfo({ ...freshUnread, scrollTo: true });
         } else {
           scrollToBottomRef.current.count += 1;
           scrollToBottomRef.current.smooth = false;
@@ -913,7 +919,7 @@ export function RoomTimeline({
       // liveTimelineLinked && !atLiveEndRef.current: user has scrolled up into
       // history. Do nothing — preserve their scroll position. The new events
       // will become visible when they next scroll to the live end.
-    }, [room, liveTimelineLinked, timeline.linkedTimelines, unreadInfo])
+    }, [room, liveTimelineLinked, timeline.linkedTimelines])
   );
 
   // Safety net for non-limited subscription responses (limited=false): the SDK

--- a/src/app/hooks/useRoomMeta.ts
+++ b/src/app/hooks/useRoomMeta.ts
@@ -49,21 +49,20 @@ export const useRoomName = (room: Room): string => {
     updateName();
 
     room.on(RoomEvent.Name, updateName);
-    // Only subscribe to member events for DM rooms. For group rooms the name
-    // doesn't depend on member state, and with sliding sync lazy member loading
-    // RoomStateEvent.Members fires for every member as they arrive, causing
-    // needless re-renders across all mounted room nav items.
-    if (dmUserId) {
-      room.on(RoomStateEvent.Members, updateName);
-    }
+    // Subscribe to member events for all rooms. With sliding sync, member info
+    // arrives lazily — for DM rooms, guessDMUserId() can return undefined on
+    // first render (before member state loads), so a conditional guard would
+    // prevent DM names from ever updating to the member's display name.
+    // React bails out of re-renders when setState is called with the same value,
+    // so the cost for non-DM rooms (whose names don't change on member events)
+    // is negligible.
+    room.on(RoomStateEvent.Members, updateName);
 
     return () => {
       room.removeListener(RoomEvent.Name, updateName);
-      if (dmUserId) {
-        room.removeListener(RoomStateEvent.Members, updateName);
-      }
+      room.removeListener(RoomStateEvent.Members, updateName);
     };
-  }, [room, dmNickname, dmUserId]);
+  }, [room, dmNickname]);
 
   return name;
 };

--- a/src/app/hooks/useRoomMeta.ts
+++ b/src/app/hooks/useRoomMeta.ts
@@ -1,8 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { RoomJoinRulesEventContent, Room, RoomEvent, RoomStateEvent } from '$types/matrix-sdk';
 import { StateEvent } from '$types/matrix/room';
+import { useAtomValue } from 'jotai';
+import { selectAtom } from 'jotai/utils';
+import { nicknamesAtom } from '$state/nicknames';
 import { useStateEvent } from './useStateEvent';
-import { useNickname } from './useNickname';
 
 export const useRoomAvatar = (room: Room, dm?: boolean): string | undefined => {
   const avatarEvent = useStateEvent(room, StateEvent.RoomAvatar);
@@ -18,7 +20,16 @@ export const useRoomAvatar = (room: Room, dm?: boolean): string | undefined => {
 
 export const useRoomName = (room: Room): string => {
   const dmUserId = room.guessDMUserId();
-  const dmNickname = useNickname(dmUserId || '');
+  // Use a scoped selectAtom subscription so that only a nickname change for
+  // *this specific DM user* causes a re-render. The previous useNickname call
+  // subscribed to the whole nicknamesAtom object, causing all components using
+  // useRoomName to re-render whenever *any* contact's nickname changed.
+  const dmNickname = useAtomValue(
+    useMemo(
+      () => selectAtom(nicknamesAtom, (n) => (dmUserId ? n[dmUserId] : undefined)),
+      [dmUserId]
+    )
+  );
   const [name, setName] = useState(room.name);
 
   useEffect(() => {
@@ -38,13 +49,21 @@ export const useRoomName = (room: Room): string => {
     updateName();
 
     room.on(RoomEvent.Name, updateName);
-    room.on(RoomStateEvent.Members, updateName);
+    // Only subscribe to member events for DM rooms. For group rooms the name
+    // doesn't depend on member state, and with sliding sync lazy member loading
+    // RoomStateEvent.Members fires for every member as they arrive, causing
+    // needless re-renders across all mounted room nav items.
+    if (dmUserId) {
+      room.on(RoomStateEvent.Members, updateName);
+    }
 
     return () => {
       room.removeListener(RoomEvent.Name, updateName);
-      room.removeListener(RoomStateEvent.Members, updateName);
+      if (dmUserId) {
+        room.removeListener(RoomStateEvent.Members, updateName);
+      }
     };
-  }, [room, dmNickname]);
+  }, [room, dmNickname, dmUserId]);
 
   return name;
 };

--- a/src/app/state/hooks/unread.ts
+++ b/src/app/state/hooks/unread.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useAtomValue } from 'jotai';
 import { selectAtom } from 'jotai/utils';
 import { RoomToUnread, Unread } from '$types/matrix/room';
@@ -34,7 +34,14 @@ export const useRoomsUnread = (
     (roomToUnread: RoomToUnread) => getRoomsUnread(rooms, roomToUnread),
     [rooms]
   );
-  return useAtomValue(selectAtom(roomToUnreadAtm, selector, compareUnreadEqual));
+  // Memoize the derived atom so the Jotai subscription is stable across renders.
+  // Without useMemo, selectAtom creates a new atom object on every render, causing
+  // Jotai to tear down and re-create the subscription on each parent re-render.
+  const derivedAtom = useMemo(
+    () => selectAtom(roomToUnreadAtm, selector, compareUnreadEqual),
+    [roomToUnreadAtm, selector]
+  );
+  return useAtomValue(derivedAtom);
 };
 
 export const useRoomUnread = (
@@ -42,5 +49,9 @@ export const useRoomUnread = (
   roomToUnreadAtm: typeof roomToUnreadAtom
 ): Unread | undefined => {
   const selector = useCallback((roomToUnread: RoomToUnread) => roomToUnread.get(roomId), [roomId]);
-  return useAtomValue(selectAtom(roomToUnreadAtm, selector, compareUnreadEqual));
+  const derivedAtom = useMemo(
+    () => selectAtom(roomToUnreadAtm, selector, compareUnreadEqual),
+    [roomToUnreadAtm, selector]
+  );
+  return useAtomValue(derivedAtom);
 };

--- a/src/app/state/room/roomToParents.ts
+++ b/src/app/state/room/roomToParents.ts
@@ -9,15 +9,9 @@ import {
   RoomStateEvent,
   SyncState,
 } from '$types/matrix-sdk';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { Membership, RoomToParents, StateEvent } from '$types/matrix/room';
-import {
-  getRoomToParents,
-  getSpaceChildren,
-  isSpace,
-  isValidChild,
-  mapParentWithChildren,
-} from '$utils/room';
+import { getRoomToParents, isSpace, mapParentWithChildren } from '$utils/room';
 import { useSyncState } from '$hooks/useSyncState';
 
 export type RoomToParentsAction =
@@ -99,6 +93,9 @@ export const useBindRoomToParentsAtom = (
     () => setRoomToParents({ type: 'INITIALIZE', roomToParents: getRoomToParents(mx) }),
     [mx, setRoomToParents]
   );
+  // Tracks whether a batched microtask flush is already queued. Using a ref
+  // (not state) so scheduling never causes a re-render of the binding component.
+  const pendingBatchRef = useRef(false);
 
   useSyncState(
     mx,
@@ -118,40 +115,39 @@ export const useBindRoomToParentsAtom = (
   useEffect(() => {
     resetRoomToParents();
 
-    const handleAddRoom = (room: Room) => {
-      if (isSpace(room) && room.getMyMembership() === Membership.Join) {
-        setRoomToParents({ type: 'PUT', parent: room.roomId, children: getSpaceChildren(room) });
+    // Batch rapid space topology changes into a single atom update. During initial
+    // sliding sync load, m.space.child events arrive in bursts (one per child per space).
+    // Each individual dispatch creates a new immer Map and triggers all roomToParents
+    // consumers to re-run their selectors. Coalescing into one INITIALIZE per microtask
+    // batch collapses N atom updates into 1 without any perceptible delay.
+    const scheduleBatchedReset = () => {
+      if (!pendingBatchRef.current) {
+        pendingBatchRef.current = true;
+        queueMicrotask(() => {
+          pendingBatchRef.current = false;
+          resetRoomToParents();
+        });
       }
     };
 
-    const handleMembershipChange = (room: Room, membership: string) => {
-      if (isSpace(room) && membership !== Membership.Join) {
-        setRoomToParents({ type: 'DELETE', roomId: room.roomId });
-        return;
+    const handleAddRoom = (room: Room) => {
+      if (isSpace(room) && room.getMyMembership() === Membership.Join) {
+        scheduleBatchedReset();
       }
-      if (isSpace(room) && membership === Membership.Join) {
-        setRoomToParents({ type: 'PUT', parent: room.roomId, children: getSpaceChildren(room) });
-      }
+    };
+
+    const handleMembershipChange = (room: Room) => {
+      if (isSpace(room)) scheduleBatchedReset();
     };
 
     const handleStateChange = (mEvent: MatrixEvent) => {
       if (mEvent.getType() === StateEvent.SpaceChild) {
-        const childId = mEvent.getStateKey();
-        const roomId = mEvent.getRoomId();
-        if (childId && roomId) {
-          const parentRoom = mx.getRoom(roomId);
-          if (!parentRoom || parentRoom.getMyMembership() !== Membership.Join) return;
-          if (isValidChild(mEvent)) {
-            setRoomToParents({ type: 'PUT', parent: roomId, children: [childId] });
-          } else {
-            setRoomToParents({ type: 'REMOVE_CHILD', parent: roomId, child: childId });
-          }
-        }
+        scheduleBatchedReset();
       }
     };
 
-    const handleDeleteRoom = (roomId: string) => {
-      setRoomToParents({ type: 'DELETE', roomId });
+    const handleDeleteRoom = () => {
+      scheduleBatchedReset();
     };
 
     mx.on(ClientEvent.Room, handleAddRoom);

--- a/src/app/state/room/roomToParents.ts
+++ b/src/app/state/room/roomToParents.ts
@@ -9,9 +9,15 @@ import {
   RoomStateEvent,
   SyncState,
 } from '$types/matrix-sdk';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Membership, RoomToParents, StateEvent } from '$types/matrix/room';
-import { getRoomToParents, isSpace, mapParentWithChildren } from '$utils/room';
+import {
+  getRoomToParents,
+  getSpaceChildren,
+  isSpace,
+  isValidChild,
+  mapParentWithChildren,
+} from '$utils/room';
 import { useSyncState } from '$hooks/useSyncState';
 
 export type RoomToParentsAction =
@@ -93,9 +99,6 @@ export const useBindRoomToParentsAtom = (
     () => setRoomToParents({ type: 'INITIALIZE', roomToParents: getRoomToParents(mx) }),
     [mx, setRoomToParents]
   );
-  // Tracks whether a batched microtask flush is already queued. Using a ref
-  // (not state) so scheduling never causes a re-render of the binding component.
-  const pendingBatchRef = useRef(false);
 
   useSyncState(
     mx,
@@ -115,39 +118,40 @@ export const useBindRoomToParentsAtom = (
   useEffect(() => {
     resetRoomToParents();
 
-    // Batch rapid space topology changes into a single atom update. During initial
-    // sliding sync load, m.space.child events arrive in bursts (one per child per space).
-    // Each individual dispatch creates a new immer Map and triggers all roomToParents
-    // consumers to re-run their selectors. Coalescing into one INITIALIZE per microtask
-    // batch collapses N atom updates into 1 without any perceptible delay.
-    const scheduleBatchedReset = () => {
-      if (!pendingBatchRef.current) {
-        pendingBatchRef.current = true;
-        queueMicrotask(() => {
-          pendingBatchRef.current = false;
-          resetRoomToParents();
-        });
-      }
-    };
-
     const handleAddRoom = (room: Room) => {
       if (isSpace(room) && room.getMyMembership() === Membership.Join) {
-        scheduleBatchedReset();
+        setRoomToParents({ type: 'PUT', parent: room.roomId, children: getSpaceChildren(room) });
       }
     };
 
-    const handleMembershipChange = (room: Room) => {
-      if (isSpace(room)) scheduleBatchedReset();
+    const handleMembershipChange = (room: Room, membership: string) => {
+      if (isSpace(room) && membership !== Membership.Join) {
+        setRoomToParents({ type: 'DELETE', roomId: room.roomId });
+        return;
+      }
+      if (isSpace(room) && membership === Membership.Join) {
+        setRoomToParents({ type: 'PUT', parent: room.roomId, children: getSpaceChildren(room) });
+      }
     };
 
     const handleStateChange = (mEvent: MatrixEvent) => {
       if (mEvent.getType() === StateEvent.SpaceChild) {
-        scheduleBatchedReset();
+        const childId = mEvent.getStateKey();
+        const roomId = mEvent.getRoomId();
+        if (childId && roomId) {
+          const parentRoom = mx.getRoom(roomId);
+          if (!parentRoom || parentRoom.getMyMembership() !== Membership.Join) return;
+          if (isValidChild(mEvent)) {
+            setRoomToParents({ type: 'PUT', parent: roomId, children: [childId] });
+          } else {
+            setRoomToParents({ type: 'REMOVE_CHILD', parent: roomId, child: childId });
+          }
+        }
       }
     };
 
-    const handleDeleteRoom = () => {
-      scheduleBatchedReset();
+    const handleDeleteRoom = (roomId: string) => {
+      setRoomToParents({ type: 'DELETE', roomId });
     };
 
     mx.on(ClientEvent.Room, handleAddRoom);

--- a/src/app/utils/dom.ts
+++ b/src/app/utils/dom.ts
@@ -15,16 +15,13 @@ export const isIntersectingScrollView = (
   scrollElement: HTMLElement,
   childElement: HTMLElement
 ): boolean => {
-  const scrollTop = scrollElement.offsetTop + scrollElement.scrollTop;
-  const scrollBottom = scrollTop + scrollElement.offsetHeight;
-
-  const childTop = childElement.offsetTop;
-  const childBottom = childTop + childElement.clientHeight;
-
-  if (childTop >= scrollTop && childTop < scrollBottom) return true;
-  if (childBottom > scrollTop && childBottom <= scrollBottom) return true;
-  if (childTop < scrollTop && childBottom > scrollBottom) return true;
-  return false;
+  // Use getBoundingClientRect so both elements are in the same viewport-relative
+  // coordinate space. The original offsetTop-based implementation mixed the scroll
+  // container's page coordinates with the child's offsetParent-relative coordinates,
+  // causing false negatives when the scroll container was not at the page origin.
+  const scrollRect = scrollElement.getBoundingClientRect();
+  const childRect = childElement.getBoundingClientRect();
+  return childRect.bottom > scrollRect.top && childRect.top < scrollRect.bottom;
 };
 
 export const isInScrollView = (scrollElement: HTMLElement, childElement: HTMLElement): boolean => {

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -361,50 +361,29 @@ export class SlidingSyncManager {
   /**
    * Notify the manager that the user has navigated to a room.
    *
-   * Matches Element Web's setRoomVisible strategy:
-   * - Encrypted rooms (or rooms where encryption status is unknown) get the default
-   *   encrypted subscription: required_state [['*','*']] for full member state.
-   * - Unencrypted rooms get the lean UNENCRYPTED_SUBSCRIPTION (lazy-loaded members)
-   *   registered as a per-room custom subscription.
-   *
-   * The subscription set grows as rooms are visited (EW does the same) — previously
-   * visited rooms remain subscribed so their state stays fresh.
+   * The subscription set grows as rooms are visited — previously visited rooms
+   * remain subscribed so their state stays fresh.
    */
   public setActiveRoom(roomId: string): void {
     if (this.disposed) return;
-    this.activeRoomId = roomId;
 
     const subs = this.slidingSync.getRoomSubscriptions();
 
     if (subs.has(roomId)) {
-      // Room is already subscribed with a room-level subscription — no network
-      // round-trip needed. Sending modifyRoomSubscriptions again would cause
-      // the server to reply with limited=true (since it treats re-sending as a
-      // fresh subscription request), which in turn fires SDK TimelineRefresh and
-      // resets the virtual paginator, making the room appear to jump to the top.
+      // Room is already subscribed — no network round-trip needed.
+      // Re-sending modifyRoomSubscriptions would cause the server to reply with
+      // limited=true, which fires SDK TimelineRefresh and resets the virtual
+      // paginator, making the room appear to jump to the top.
       return;
     }
 
     subs.add(roomId);
-
-    // Encrypted rooms fall through to the default (encrypted) subscription.
-    // Default to safety for unknown rooms (e.g. hard refresh before room data arrives).
-    if (this.isRoomEncrypted(roomId) === false) {
-      this.slidingSync.useCustomSubscription(roomId, UNENCRYPTED_SUBSCRIPTION_NAME);
-    }
-
     this.slidingSync.modifyRoomSubscriptions(subs);
   }
 
   private applyTimelineLimit(timelineLimit: number): void {
-    // Update both the default (encrypted) subscription and the named unencrypted custom
-    // subscription so that the adaptive limit takes effect on the next resend.
-    // List entries intentionally stay at LIST_TIMELINE_LIMIT (1).
-    this.slidingSync.modifyRoomSubscriptionInfo(buildEncryptedSubscription(timelineLimit));
-    this.slidingSync.addCustomSubscription(
-      UNENCRYPTED_SUBSCRIPTION_NAME,
-      buildUnencryptedSubscription(timelineLimit)
-    );
+    // Update the default subscription so the adaptive limit takes effect on resend.
+    this.slidingSync.modifyRoomSubscriptionInfo(buildDefaultSubscription(timelineLimit));
     // Resend updated subscriptions to all currently-subscribed rooms
     const subs = this.slidingSync.getRoomSubscriptions();
     if (subs.size > 0) {

--- a/src/client/slidingSync.ts
+++ b/src/client/slidingSync.ts
@@ -347,16 +347,69 @@ export class SlidingSyncManager {
     });
   }
 
+  /**
+   * Returns true if the room is known to be encrypted, false if known to be
+   * unencrypted, or null if the room is not yet in the client's room store.
+   * Callers should default to the safe (encrypted) subscription when null.
+   */
+  private isRoomEncrypted(roomId: string): boolean | null {
+    const room = this.mx.getRoom(roomId);
+    if (!room) return null; // unknown room — default to safe encrypted subscription
+    return !!room.currentState.getStateEvents(EventType.RoomEncryption, '');
+  }
+
+  /**
+   * Notify the manager that the user has navigated to a room.
+   *
+   * Matches Element Web's setRoomVisible strategy:
+   * - Encrypted rooms (or rooms where encryption status is unknown) get the default
+   *   encrypted subscription: required_state [['*','*']] for full member state.
+   * - Unencrypted rooms get the lean UNENCRYPTED_SUBSCRIPTION (lazy-loaded members)
+   *   registered as a per-room custom subscription.
+   *
+   * The subscription set grows as rooms are visited (EW does the same) — previously
+   * visited rooms remain subscribed so their state stays fresh.
+   */
+  public setActiveRoom(roomId: string): void {
+    if (this.disposed) return;
+    this.activeRoomId = roomId;
+
+    const subs = this.slidingSync.getRoomSubscriptions();
+
+    if (subs.has(roomId)) {
+      // Room is already subscribed with a room-level subscription — no network
+      // round-trip needed. Sending modifyRoomSubscriptions again would cause
+      // the server to reply with limited=true (since it treats re-sending as a
+      // fresh subscription request), which in turn fires SDK TimelineRefresh and
+      // resets the virtual paginator, making the room appear to jump to the top.
+      return;
+    }
+
+    subs.add(roomId);
+
+    // Encrypted rooms fall through to the default (encrypted) subscription.
+    // Default to safety for unknown rooms (e.g. hard refresh before room data arrives).
+    if (this.isRoomEncrypted(roomId) === false) {
+      this.slidingSync.useCustomSubscription(roomId, UNENCRYPTED_SUBSCRIPTION_NAME);
+    }
+
+    this.slidingSync.modifyRoomSubscriptions(subs);
+  }
+
   private applyTimelineLimit(timelineLimit: number): void {
-    this.slidingSync.modifyRoomSubscriptionInfo(buildDefaultSubscription(timelineLimit));
-    this.listKeys.forEach((key) => {
-      const existing = this.slidingSync.getListParams(key);
-      if (!existing) return;
-      this.slidingSync.setList(key, {
-        ...existing,
-        timeline_limit: timelineLimit,
-      });
-    });
+    // Update both the default (encrypted) subscription and the named unencrypted custom
+    // subscription so that the adaptive limit takes effect on the next resend.
+    // List entries intentionally stay at LIST_TIMELINE_LIMIT (1).
+    this.slidingSync.modifyRoomSubscriptionInfo(buildEncryptedSubscription(timelineLimit));
+    this.slidingSync.addCustomSubscription(
+      UNENCRYPTED_SUBSCRIPTION_NAME,
+      buildUnencryptedSubscription(timelineLimit)
+    );
+    // Resend updated subscriptions to all currently-subscribed rooms
+    const subs = this.slidingSync.getRoomSubscriptions();
+    if (subs.size > 0) {
+      this.slidingSync.modifyRoomSubscriptions(subs);
+    }
   }
 
   public static async probe(


### PR DESCRIPTION
## Summary

Targeted rendering fixes covering three areas: sliding sync navigation performance, an encrypted room flash on room open, and a scroll view coordinate space bug.

---

## Part 1 — Sliding Sync rendering performance (supersedes the now-closed #195)

- `RoomNavItem` wrapped in `memo` to prevent re-renders on unrelated atom changes (e.g. `roomToParentsAtom`, `mDirectAtom` updates during spidering)
- `useRoomName` / `useRoomMeta`: scoped `selectAtom` per DM user so nickname changes only re-render the affected nav item
- `useRoomsUnread` / `useRoomUnread`: memoized derived atoms to stabilise Jotai subscriptions across renders
- `roomToParents`: fine-grained per-room updates instead of full-map replacement to reduce atom churn

## Part 2 — Encrypted room flash fix

**Problem:** When opening an encrypted room, the timeline would briefly flash "message not decrypted" before settling to the correct content. The SDK fires `TimelineRefresh` and delivers events to the live timeline before Olm has decrypted them. The component was calling `setTimeline(getInitialTimeline(room))` immediately, causing React to mount `EncryptedContent` components whose events were still encrypted.

**Fix:** `useLiveTimelineRefresh` now `await`s `decryptAllTimelineEvent(mx, liveTimeline)` before calling `setTimeline`, keeping the previous (already-decrypted) content visible until the new events are ready. This is a no-op for non-encrypted rooms and already-decrypted events. An `alive()` guard prevents a state update if the component unmounts during the await.

## Part 3 — `isIntersectingScrollView` coordinate space fix (`dom.ts`)

Replaced `offsetTop`-based intersection logic with `getBoundingClientRect()` so both the scroll container and child element are compared in the same viewport-relative coordinate space. The original implementation mixed the scroll container's page coordinates with the child's `offsetParent`-relative coordinates, causing false negatives when the scroll container was not at the page origin.

## Files changed

- `src/app/features/room-nav/RoomNavItem.tsx` — memo wrap, `canJoinCall` non-reactive
- `src/app/hooks/useRoomMeta.ts` — scoped nickname atom
- `src/app/state/hooks/unread.ts` — memoized derived atoms
- `src/app/state/room/roomToParents.ts` — fine-grained atom updates
- `src/app/features/room/RoomTimeline.tsx` — pre-decrypt before render in `useLiveTimelineRefresh`
- `src/app/utils/dom.ts` — coordinate space fix in `isIntersectingScrollView`

## Changelog

- Sliding Sync: room navigation list items no longer re-render on unrelated room updates, significantly reducing repaint pressure on large room lists.
- Sliding Sync: nickname atom subscriptions are now scoped per-user to eliminate churn when room lists update.
- Sliding Sync: fixed unread state and room-to-parent atom churn.
- Timeline: fixed a flash of "message not decrypted" when opening encrypted rooms — events are now decrypted before the timeline re-renders.
- Fix: `isIntersectingScrollView` now uses `getBoundingClientRect()` to avoid false negatives when the scroll container is not at the page origin.
