### PR TITLE
Add message forwarding

### DIFF
--- a/.changeset/add_message_forwarding.md
+++ b/.changeset/add_message_forwarding.md
@@ -1,5 +1,5 @@
 ---
-sable: patch
+sable: minor
 ---
 
 Add message forwarding with metadata

--- a/.changeset/add_message_forwarding.md
+++ b/.changeset/add_message_forwarding.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Add message forwarding with metadata

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -31,6 +31,7 @@ import {
   MessageUnsupportedContent,
 } from './content';
 import { MessageTextBody } from './layout';
+import { unwrapForwardedContent } from './modals/MessageForward';
 
 export function MBadEncrypted() {
   return (
@@ -86,6 +87,10 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
     typeof content.formatted_body === 'string' ? content.formatted_body : undefined;
 
   const trimmedBody = useMemo(() => trimReplyFromBody(body), [body]);
+  const unwrappedForwardedContent = useMemo(
+    () => unwrapForwardedContent(customBody ?? body),
+    [customBody, body]
+  );
 
   const safeCustomBody = useMemo(() => {
     if (!customBody) return undefined;
@@ -96,6 +101,10 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
     return customBody;
   }, [customBody]);
 
+  const isForwarded = useMemo(() => {
+    const forwardMeta = content['moe.sable.message.forward'];
+    return typeof forwardMeta === 'object';
+  }, [content]);
   const isJumbo = useMemo(() => {
     if (!trimmedBody || trimmedBody.length >= 500) return false;
     if (!JUMBO_EMOJI_REG.test(trimmedBody)) return false;
@@ -112,6 +121,19 @@ export function MText({ edited, content, renderBody, renderUrlsPreview, style }:
 
   const urlsMatch = renderUrlsPreview && trimmedBody.match(URL_REG);
   const urls = urlsMatch ? [...new Set(urlsMatch)] : undefined;
+
+  if (isForwarded && unwrappedForwardedContent) {
+    return (
+      <MessageTextBody preWrap={typeof unwrappedForwardedContent !== 'string'} style={style}>
+        {renderBody({
+          body: trimmedBody,
+          customBody: unwrappedForwardedContent,
+        })}
+        {edited && <MessageEditedContent />}
+        {renderUrlsPreview && urls && urls.length > 0 && renderUrlsPreview(urls)}
+      </MessageTextBody>
+    );
+  }
 
   return (
     <>

--- a/src/app/components/message/modals/GlobalModalManager.tsx
+++ b/src/app/components/message/modals/GlobalModalManager.tsx
@@ -6,6 +6,7 @@ import { modalAtom, ModalType } from '$state/modal';
 import { MessageReportInternal } from './MessageReport';
 import { MessageDeleteInternal } from './MessageDelete';
 import { MessageSourceInternal } from './MessageSource';
+import { MessageForwardInternal } from './MessageForward';
 import { MessageAllReactionInternal } from './MessageReactions';
 import { MessageReadReceiptInternal } from './MessageReadRecipts';
 
@@ -37,6 +38,12 @@ export function GlobalModalManager() {
             {modal.type === ModalType.Delete && (
               <Box>
                 <MessageDeleteInternal room={modal.room} mEvent={modal.mEvent} onClose={close} />
+              </Box>
+            )}
+
+            {modal.type === ModalType.Forward && (
+              <Box>
+                <MessageForwardInternal room={modal.room} mEvent={modal.mEvent} onClose={close} />
               </Box>
             )}
 

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -21,6 +21,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { allRoomsAtom } from '$state/room-list/roomList';
 import { useAllJoinedRoomsSet, useGetRoom } from '$hooks/useGetRoom';
 import { factoryRoomIdByActivity } from '$utils/sort';
+import { set } from 'immer/dist/internal.js';
 
 // Message forwarding component
 export function MessageForwardItem({
@@ -75,6 +76,7 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
 
   const [isTargetSelected, setIsTargetSelected] = useState(false);
   const [isForwardSuccess, setIsForwardSuccess] = useState(false);
+  const [isForwardError, setIsForwardError] = useState(false);
   const [targetRoomId, setTargetRoomId] = useState<string | null>(null);
 
   const allRooms = useAtomValue(allRoomsAtom);
@@ -132,15 +134,13 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     };
 
     try {
-      mx.sendEvent(targetRoom.roomId, null, eventType, content as unknown as SendEventContent)
-        .then(() => setIsForwardSuccess(true))
-        .catch((err) => {
-          console.error('Failed to forward message', err);
-        });
-    } catch (err) {
-      console.error('Failed to forward message', err);
+      mx.sendEvent(targetRoom.roomId, null, eventType, content as unknown as SendEventContent).then(
+        () => setIsForwardSuccess(true)
+      );
+    } catch {
+      setIsForwardSuccess(false);
+      setIsForwardError(true);
     }
-    onClose();
   };
 
   return (
@@ -185,10 +185,15 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
             })}
           </Box>
         </Scroll>
-        {isTargetSelected && (
+        {isTargetSelected && targetRoomId && (
           <Button style={{ margin: config.space.S300 }} onClick={handleForwardClick}>
             <Text>Forward to {getRoom(targetRoomId)?.name}</Text>
           </Button>
+        )}
+        {isForwardError && (
+          <Text size="T300" color="Critical600" style={{ margin: config.space.S300 }}>
+            Failed to forward message. Please try again.
+          </Text>
         )}
       </Box>
     </Dialog>

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -16,7 +16,7 @@ import {
   Scroll,
 } from 'folds';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { MatrixEvent, Room } from '$types/matrix-sdk';
+import { IContent, MatrixEvent, Room } from '$types/matrix-sdk';
 import { useEffect, useMemo, useState } from 'react';
 import { allRoomsAtom } from '$state/room-list/roomList';
 import { useAllJoinedRoomsSet, useGetRoom } from '$hooks/useGetRoom';
@@ -61,6 +61,13 @@ type MessageForwardInternalProps = {
   room: Room;
   mEvent: MatrixEvent;
   onClose: () => void;
+};
+
+type ForwardMeta = {
+  v: 1;
+  is_forwarded: true;
+  original_timestamp: number;
+  original_room_id: string;
 };
 
 export function MessageForwardInternal({ room, mEvent, onClose }: MessageForwardInternalProps) {
@@ -109,19 +116,30 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     const eventType = mEvent.getType() as SendEventType;
     // using reference relation to indicate that this is a forwarded message,
     // which allows clients to display it as such
+    // maybe not the best idea to include the original room id as that could leak information about the user's room list
     const content = {
       ...mEvent.getContent(),
       'm.relates_to': {
         rel_type: 'm.reference',
         event_id: eventId,
       },
-    } as SendEventContent;
+      'moe.sable.message.forward': {
+        v: 1,
+        is_forwarded: true,
+        original_timestamp: mEvent.getTs(),
+        original_room_id: room.roomId,
+      } satisfies ForwardMeta,
+    };
 
-    mx.sendEvent(targetRoom.roomId, null, eventType, content)
-      .then(() => setIsForwardSuccess(true))
-      .catch((err) => {
-        console.error('Failed to forward message', err);
-      });
+    try {
+      mx.sendEvent(targetRoom.roomId, null, eventType, content as unknown as SendEventContent)
+        .then(() => setIsForwardSuccess(true))
+        .catch((err) => {
+          console.error('Failed to forward message', err);
+        });
+    } catch (err) {
+      console.error('Failed to forward message', err);
+    }
     onClose();
   };
 

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -26,8 +26,6 @@ import * as css from '$features/room/message/styles.css';
 import { sanitizeCustomHtml } from '$utils/sanitize';
 import { getStateEvents } from '$utils/room';
 import { StateEvent } from '$types/matrix/room';
-import { getViaServers } from '$plugins/via-servers';
-import { getMatrixToRoomEvent } from '$plugins/matrix-to';
 
 // Message forwarding component
 export const MessageForwardItem = as<'button', MessageForwardItemProps>(

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -16,7 +16,7 @@ import {
   Scroll,
 } from 'folds';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { IContent, MatrixEvent, Room } from '$types/matrix-sdk';
+import { MatrixEvent, Room } from '$types/matrix-sdk';
 import { useEffect, useMemo, useState } from 'react';
 import { allRoomsAtom } from '$state/room-list/roomList';
 import { useAllJoinedRoomsSet, useGetRoom } from '$hooks/useGetRoom';
@@ -87,7 +87,7 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
         .filter((id) => id !== room.roomId)
         .filter((id) => {
           const target = getRoom(id);
-          return !!target && !target.isSpaceRoom();
+          return !!target && !target.isSpaceRoom() && target.maySendMessage();
         })
         .sort(factoryRoomIdByActivity(mx)),
     [allRooms, room.roomId, getRoom, mx]

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -1,0 +1,70 @@
+// Modal for message forwarding, which allows users to select a room to forward the message to
+
+import { useMatrixClient } from '$hooks/useMatrixClient';
+import { modalAtom, ModalType } from '$state/modal';
+import { Avatar, Box, Button, Dialog, Header, Icon, Icons, IconButton, MenuItem, Text, config } from 'folds';
+import { useSetAtom } from 'jotai';
+import { MatrixEvent, Room } from '$types/matrix-sdk';
+
+// Message forwarding component
+export function MessageForwardItem({
+  room,
+  mEvent,
+  onClose,
+}: {
+  room: Room;
+  mEvent: MatrixEvent;
+  onClose: () => void;
+}) {
+  const setModal = useSetAtom(modalAtom);
+
+  const handleClick = () => {
+    setModal({
+      type: ModalType.Forward,
+      room,
+      mEvent,
+    });
+    onClose();
+  };
+
+  return (
+    <MenuItem
+      size="300"
+      after={<Icon size="100" src={Icons.ReplyArrow} />}
+      radii="300"
+      onClick={handleClick}
+    >
+      <Text as="span" size="T300" truncate>
+        Forward
+      </Text>
+    </MenuItem>
+  );
+}
+
+type MessageForwardInternalProps = {
+  room: Room;
+  mEvent: MatrixEvent;
+  onClose: () => void;
+};
+
+export function MessageForwardInternal({ room, mEvent, onClose }: MessageForwardInternalProps) {
+  return (
+    <Dialog variant="Surface">
+      <Header
+        style={{
+          padding: `0 ${config.space.S200} 0 ${config.space.S400}`,
+          borderBottomWidth: config.borderWidth.B300,
+        }}
+        variant="Surface"
+        size="500"
+      >
+        <Box grow="Yes">
+          <Text size="H4">Forward Message</Text>
+        </Box>
+        <IconButton size="300" onClick={onClose} radii="300">
+          <Icon src={Icons.Cross} />
+        </IconButton>
+      </Header>
+    </Dialog>
+  );
+}

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -2,9 +2,25 @@
 
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { modalAtom, ModalType } from '$state/modal';
-import { Avatar, Box, Button, Dialog, Header, Icon, Icons, IconButton, MenuItem, Text, config } from 'folds';
-import { useSetAtom } from 'jotai';
+import {
+  Box,
+  Button,
+  Dialog,
+  Header,
+  Icon,
+  Icons,
+  IconButton,
+  MenuItem,
+  Text,
+  config,
+  Scroll,
+} from 'folds';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { MatrixEvent, Room } from '$types/matrix-sdk';
+import { useMemo, useState } from 'react';
+import { allRoomsAtom } from '$state/room-list/roomList';
+import { useAllJoinedRoomsSet, useGetRoom } from '$hooks/useGetRoom';
+import { factoryRoomIdByActivity } from '$utils/sort';
 
 // Message forwarding component
 export function MessageForwardItem({
@@ -48,6 +64,53 @@ type MessageForwardInternalProps = {
 };
 
 export function MessageForwardInternal({ room, mEvent, onClose }: MessageForwardInternalProps) {
+  const mx = useMatrixClient();
+
+  const [isTargetSelected, setIsTargetSelected] = useState(false);
+  const [targetRoomId, setTargetRoomId] = useState<string | null>(null);
+
+  const allRooms = useAtomValue(allRoomsAtom);
+  const allJoinedRooms = useAllJoinedRoomsSet();
+  const getRoom = useGetRoom(allJoinedRooms);
+  // possible targets to forward the message to
+  const forwardTargets = useMemo(
+    () =>
+      allRooms
+        .filter((id) => id !== room.roomId)
+        .filter((id) => {
+          const target = getRoom(id);
+          return !!target && !target.isSpaceRoom();
+        })
+        .sort(factoryRoomIdByActivity(mx)),
+    [allRooms, room.roomId, getRoom, mx]
+  );
+
+  // actually forward the message to the selected room
+  const handleForwardClick = (event: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => {
+    const { roomId } = event.currentTarget.dataset;
+    if (!roomId) return;
+
+    const targetRoom = getRoom(roomId);
+    const eventId = mEvent.getId();
+    if (!targetRoom || !eventId) return;
+
+    type SendEventType = Parameters<typeof mx.sendEvent>[2];
+    type SendEventContent = Parameters<typeof mx.sendEvent>[3];
+
+    const eventType = mEvent.getType() as SendEventType;
+    const content = {
+      ...mEvent.getContent(),
+      'm.relates_to': {
+        'm.in_reply_to': {
+          event_id: eventId,
+        },
+      },
+    } as SendEventContent;
+
+    mx.sendEvent(targetRoom.roomId, null, eventType, content);
+    onClose();
+  };
+
   return (
     <Dialog variant="Surface">
       <Header
@@ -65,6 +128,37 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
           <Icon src={Icons.Cross} />
         </IconButton>
       </Header>
+      <Box direction="Column" style={{ height: '300px' }}>
+        <Scroll hideTrack>
+          <Box direction="Column" style={{ padding: config.space.S300 }}>
+            {forwardTargets.map((roomId) => {
+              const target = getRoom(roomId);
+              if (!target) return null;
+              return (
+                <MenuItem
+                  key={roomId}
+                  data-room-id={roomId}
+                  onClick={() => {
+                    setIsTargetSelected(true);
+                    setTargetRoomId(roomId);
+                  }}
+                  variant={targetRoomId === roomId ? 'Success' : 'Surface'}
+                  aria-pressed={targetRoomId === roomId}
+                  size="400"
+                  radii="400"
+                >
+                  <Text truncate>{target.name}</Text>
+                </MenuItem>
+              );
+            })}
+          </Box>
+        </Scroll>
+        {isTargetSelected && (
+          <Button style={{ margin: config.space.S300 }} onClick={handleForwardClick}>
+            <Text>Send</Text>
+          </Button>
+        )}
+      </Box>
     </Dialog>
   );
 }

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -21,7 +21,6 @@ import { useEffect, useMemo, useState } from 'react';
 import { allRoomsAtom } from '$state/room-list/roomList';
 import { useAllJoinedRoomsSet, useGetRoom } from '$hooks/useGetRoom';
 import { factoryRoomIdByActivity } from '$utils/sort';
-import { set } from 'immer/dist/internal.js';
 
 // Message forwarding component
 export function MessageForwardItem({

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -17,7 +17,7 @@ import {
 } from 'folds';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { MatrixEvent, Room } from '$types/matrix-sdk';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { allRoomsAtom } from '$state/room-list/roomList';
 import { useAllJoinedRoomsSet, useGetRoom } from '$hooks/useGetRoom';
 import { factoryRoomIdByActivity } from '$utils/sort';
@@ -67,6 +67,7 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
   const mx = useMatrixClient();
 
   const [isTargetSelected, setIsTargetSelected] = useState(false);
+  const [isForwardSuccess, setIsForwardSuccess] = useState(false);
   const [targetRoomId, setTargetRoomId] = useState<string | null>(null);
 
   const allRooms = useAtomValue(allRoomsAtom);
@@ -85,12 +86,20 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     [allRooms, room.roomId, getRoom, mx]
   );
 
-  // actually forward the message to the selected room
-  const handleForwardClick = (event: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => {
-    const { roomId } = event.currentTarget.dataset;
-    if (!roomId) return;
+  useEffect(() => {
+    if (isForwardSuccess) {
+      setTimeout(() => {
+        // close the modal if the message was forwarded successfully
+        onClose();
+      }, 2000);
+    }
+  }, [isForwardSuccess, onClose]);
 
-    const targetRoom = getRoom(roomId);
+  // actually forward the message to the selected room
+  const handleForwardClick = () => {
+    if (!targetRoomId) return;
+
+    const targetRoom = getRoom(targetRoomId);
     const eventId = mEvent.getId();
     if (!targetRoom || !eventId) return;
 
@@ -98,16 +107,21 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     type SendEventContent = Parameters<typeof mx.sendEvent>[3];
 
     const eventType = mEvent.getType() as SendEventType;
+    // using reference relation to indicate that this is a forwarded message,
+    // which allows clients to display it as such
     const content = {
       ...mEvent.getContent(),
       'm.relates_to': {
-        'm.in_reply_to': {
-          event_id: eventId,
-        },
+        rel_type: 'm.reference',
+        event_id: eventId,
       },
     } as SendEventContent;
 
-    mx.sendEvent(targetRoom.roomId, null, eventType, content);
+    mx.sendEvent(targetRoom.roomId, null, eventType, content)
+      .then(() => setIsForwardSuccess(true))
+      .catch((err) => {
+        console.error('Failed to forward message', err);
+      });
     onClose();
   };
 
@@ -155,7 +169,7 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
         </Scroll>
         {isTargetSelected && (
           <Button style={{ margin: config.space.S300 }} onClick={handleForwardClick}>
-            <Text>Send</Text>
+            <Text>Forward to {getRoom(targetRoomId)?.name}</Text>
           </Button>
         )}
       </Box>

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -26,6 +26,8 @@ import * as css from '$features/room/message/styles.css';
 import { sanitizeCustomHtml } from '$utils/sanitize';
 import { getStateEvents } from '$utils/room';
 import { StateEvent } from '$types/matrix/room';
+import { getViaServers } from '$plugins/via-servers';
+import { getMatrixToRoomEvent } from '$plugins/matrix-to';
 
 // Message forwarding component
 export const MessageForwardItem = as<'button', MessageForwardItemProps>(
@@ -156,7 +158,7 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     // using reference relation to indicate that this is a forwarded message,
     // which allows clients to display it as such
 
-    const bodyModifText = `(Forwarded message from ${isPrivate ? 'a private room' : (getRoom(room.roomId)?.name ?? 'a room')} - originally sent at ${new Date(mEvent.getTs()).toLocaleString()} )`;
+    const bodyModifText = `(Forwarded message from ${isPrivate ? 'a private room' : (getRoom(room.roomId)?.name ?? 'a room')})`;
     let newBodyPlain = '';
     let newBodyHtml = '';
     // transform if msgtype is m.text

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -16,7 +16,7 @@ import {
   Scroll,
 } from 'folds';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { MatrixEvent, Room } from '$types/matrix-sdk';
+import { JoinRule, MatrixEvent, Room } from '$types/matrix-sdk';
 import { useEffect, useMemo, useState } from 'react';
 import { allRoomsAtom } from '$state/room-list/roomList';
 import { useAllJoinedRoomsSet, useGetRoom } from '$hooks/useGetRoom';
@@ -67,8 +67,8 @@ type ForwardMeta = {
   v: 1;
   is_forwarded: true;
   original_timestamp: number;
-  original_room_id?: string;
-  original_event_id?: string;
+  original_room_id?: string | null;
+  original_event_id?: string | null;
   // to mark that event_id and room_id are not present
   original_event_hidden: boolean;
 };
@@ -80,6 +80,10 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
   const [isForwardSuccess, setIsForwardSuccess] = useState(false);
   const [isForwardError, setIsForwardError] = useState(false);
   const [targetRoomId, setTargetRoomId] = useState<string | null>(null);
+
+  // detect if it's a public room or not
+  const joinRule = room.getJoinRule() ?? JoinRule.Invite;
+  const isPrivate = joinRule !== (JoinRule.Public || JoinRule.Knock);
 
   const allRooms = useAtomValue(allRoomsAtom);
   const allJoinedRooms = useAllJoinedRoomsSet();
@@ -120,22 +124,40 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     const eventType = mEvent.getType() as SendEventType;
     // using reference relation to indicate that this is a forwarded message,
     // which allows clients to display it as such
-    // maybe not the best idea to include the original room id as that could leak information about the user's room list
-    const content = {
-      ...mEvent.getContent(),
-      'm.relates_to': {
-        rel_type: 'm.reference',
-        event_id: eventId,
-      },
-      'moe.sable.message.forward': {
-        v: 1,
-        is_forwarded: true,
-        original_timestamp: mEvent.getTs(),
-        original_room_id: room.roomId,
-        original_event_id: eventId,
-        original_event_hidden: false,
-      } satisfies ForwardMeta,
-    };
+
+    let content;
+    // handle privacy stuff
+    if (isPrivate) {
+      // if the message is from a private room, we should strip any media or mentions to avoid leaking information to the target room
+      // we can still include the original message content in the body of the message, so we'll just use a fallback text/plain content with the original message body
+      content = {
+        ...mEvent.getContent(),
+        'moe.sable.message.forward': {
+          v: 1,
+          is_forwarded: true,
+          original_timestamp: mEvent.getTs(),
+          original_room_id: null,
+          original_event_id: null,
+          original_event_hidden: true,
+        } satisfies ForwardMeta,
+      };
+    } else {
+      content = {
+        ...mEvent.getContent(),
+        'm.relates_to': {
+          rel_type: 'm.reference',
+          event_id: eventId,
+        },
+        'moe.sable.message.forward': {
+          v: 1,
+          is_forwarded: true,
+          original_timestamp: mEvent.getTs(),
+          original_room_id: room.roomId,
+          original_event_id: eventId,
+          original_event_hidden: false,
+        } satisfies ForwardMeta,
+      };
+    }
 
     try {
       mx.sendEvent(targetRoom.roomId, null, eventType, content as unknown as SendEventContent).then(

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -67,10 +67,10 @@ type ForwardMeta = {
   v: 1;
   is_forwarded: true;
   original_timestamp: number;
-  original_room_id?: string | null;
-  original_event_id?: string | null;
+  original_room_id?: string;
+  original_event_id?: string;
   // to mark that event_id and room_id are not present
-  original_event_hidden: boolean;
+  original_event_private: boolean;
 };
 
 export function MessageForwardInternal({ room, mEvent, onClose }: MessageForwardInternalProps) {
@@ -136,9 +136,7 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
           v: 1,
           is_forwarded: true,
           original_timestamp: mEvent.getTs(),
-          original_room_id: null,
-          original_event_id: null,
-          original_event_hidden: true,
+          original_event_private: true,
         } satisfies ForwardMeta,
       };
     } else {
@@ -154,7 +152,7 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
           original_timestamp: mEvent.getTs(),
           original_room_id: room.roomId,
           original_event_id: eventId,
-          original_event_hidden: false,
+          original_event_private: false,
         } satisfies ForwardMeta,
       };
     }

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -24,6 +24,8 @@ import { useAllJoinedRoomsSet, useGetRoom } from '$hooks/useGetRoom';
 import { factoryRoomIdByActivity } from '$utils/sort';
 import * as css from '$features/room/message/styles.css';
 import { sanitizeCustomHtml } from '$utils/sanitize';
+import { getStateEvents } from '$utils/room';
+import { StateEvent } from '$types/matrix/room';
 
 // Message forwarding component
 export const MessageForwardItem = as<'button', MessageForwardItemProps>(
@@ -95,7 +97,24 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
 
   // detect if it's a public room or not
   const joinRule = room.getJoinRule() ?? JoinRule.Invite;
-  const isPrivate = joinRule !== (JoinRule.Public || JoinRule.Knock);
+
+  const parentSpaceIds = getStateEvents(room, StateEvent.SpaceParent)
+    .map((e) => e.getStateKey())
+    .filter((id): id is string => Boolean(id));
+
+  const isInPublicSpace = parentSpaceIds.some((spaceId) => {
+    const space = mx.getRoom(spaceId);
+    return Boolean(space?.isSpaceRoom()) && space?.getJoinRule() === JoinRule.Public;
+  });
+
+  // A room is private if its join rule is Invite (or other non-public/non-knock/non-restricted),
+  // or it's Restricted but NOT inside a public space.
+  const isPrivate =
+    joinRule === JoinRule.Invite ||
+    (joinRule === JoinRule.Restricted && !isInPublicSpace) ||
+    (joinRule !== JoinRule.Public &&
+      joinRule !== JoinRule.Knock &&
+      joinRule !== JoinRule.Restricted);
 
   const allRooms = useAtomValue(allRoomsAtom);
   const allJoinedRooms = useAllJoinedRoomsSet();

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -67,7 +67,10 @@ type ForwardMeta = {
   v: 1;
   is_forwarded: true;
   original_timestamp: number;
-  original_room_id: string;
+  original_room_id?: string;
+  original_event_id?: string;
+  // to mark that event_id and room_id are not present
+  original_event_hidden: boolean;
 };
 
 export function MessageForwardInternal({ room, mEvent, onClose }: MessageForwardInternalProps) {
@@ -129,6 +132,8 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
         is_forwarded: true,
         original_timestamp: mEvent.getTs(),
         original_room_id: room.roomId,
+        original_event_id: eventId,
+        original_event_hidden: false,
       } satisfies ForwardMeta,
     };
 

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -14,6 +14,7 @@ import {
   Text,
   config,
   Scroll,
+  as,
 } from 'folds';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { JoinRule, MatrixEvent, Room } from '$types/matrix-sdk';
@@ -21,41 +22,52 @@ import { useEffect, useMemo, useState } from 'react';
 import { allRoomsAtom } from '$state/room-list/roomList';
 import { useAllJoinedRoomsSet, useGetRoom } from '$hooks/useGetRoom';
 import { factoryRoomIdByActivity } from '$utils/sort';
+import * as css from '$features/room/message/styles.css';
+import { sanitizeCustomHtml } from '$utils/sanitize';
 
 // Message forwarding component
-export function MessageForwardItem({
-  room,
-  mEvent,
-  onClose,
-}: {
-  room: Room;
-  mEvent: MatrixEvent;
-  onClose: () => void;
-}) {
-  const setModal = useSetAtom(modalAtom);
+export const MessageForwardItem = as<'button', MessageForwardItemProps>(
+  ({ room, mEvent, onClose, ...props }: MessageForwardItemProps) => {
+    const setModal = useSetAtom(modalAtom);
 
-  const handleClick = () => {
-    setModal({
-      type: ModalType.Forward,
-      room,
-      mEvent,
-    });
-    onClose();
-  };
+    const handleClick = () => {
+      setModal({
+        type: ModalType.Forward,
+        room,
+        mEvent,
+      });
+      onClose?.();
+    };
 
-  return (
-    <MenuItem
-      size="300"
-      after={<Icon size="100" src={Icons.ReplyArrow} />}
-      radii="300"
-      onClick={handleClick}
-    >
-      <Text as="span" size="T300" truncate>
-        Forward
-      </Text>
-    </MenuItem>
-  );
-}
+    return (
+      <MenuItem
+        size="300"
+        after={<Icon size="100" src={Icons.ArrowRight} />}
+        radii="300"
+        {...props}
+        onClick={handleClick}
+      >
+        <Text className={css.MessageMenuItemText} as="span" size="T300" truncate>
+          Forward
+        </Text>
+      </MenuItem>
+    );
+  }
+);
+
+export const unwrapForwardedContent = (content: string) => {
+  // unwrap the content of a forwarded message if it was wrapped in a blockquote with the data-forward-marker attribute
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(content, 'text/html');
+  const forwardMarker = doc.querySelector('[data-forward-marker]');
+  if (forwardMarker) {
+    const blockquote = forwardMarker.querySelector('blockquote');
+    if (blockquote) {
+      return blockquote.innerHTML;
+    }
+  }
+  return content;
+};
 
 type MessageForwardInternalProps = {
   room: Room;
@@ -125,6 +137,23 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     // using reference relation to indicate that this is a forwarded message,
     // which allows clients to display it as such
 
+    const bodyModifText = `(Forwarded message from ${isPrivate ? 'a private room' : (getRoom(room.roomId)?.name ?? 'a room')} - originally sent at ${new Date(mEvent.getTs()).toLocaleString()} )`;
+    let newBodyPlain = '';
+    let newBodyHtml = '';
+    // transform if msgtype is m.text
+    if (mEvent.getContent().msgtype === 'm.text') {
+      const original = mEvent.getContent().body;
+      newBodyPlain = `${bodyModifText}\n\n${original
+        .split('\n')
+        .map((l: string) => `> ${l}`)
+        .join('\n')}`;
+      const safeHtml = sanitizeCustomHtml(original).replace(/\n/g, '<br>');
+      newBodyHtml =
+        `<div class="forwarded" data-forward-marker>` +
+        `<p>${sanitizeCustomHtml(bodyModifText)}</p>` +
+        `<blockquote>${safeHtml}</blockquote>` +
+        `</div>`;
+    }
     let content;
     // handle privacy stuff
     if (isPrivate) {
@@ -132,6 +161,9 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
       // we can still include the original message content in the body of the message, so we'll just use a fallback text/plain content with the original message body
       content = {
         ...mEvent.getContent(),
+        body: newBodyPlain,
+        format: 'org.matrix.custom.html',
+        formatted_body: newBodyHtml,
         'moe.sable.message.forward': {
           v: 1,
           is_forwarded: true,
@@ -142,6 +174,9 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     } else {
       content = {
         ...mEvent.getContent(),
+        body: newBodyPlain,
+        format: 'org.matrix.custom.html',
+        formatted_body: newBodyHtml,
         'm.relates_to': {
           rel_type: 'm.reference',
           event_id: eventId,
@@ -223,3 +258,9 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     </Dialog>
   );
 }
+
+type MessageForwardItemProps = {
+  room: Room;
+  mEvent: MatrixEvent;
+  onClose?: () => void;
+};

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1314,10 +1314,10 @@ export function RoomTimeline({
         // determine if message is forwarded by checking for the presence of the 'moe.sable.message.forward' key in the event content
         const forwardContent = safeContent['moe.sable.message.forward'] as
           | {
-              original_event_hidden: boolean;
               original_timestamp?: unknown;
               original_room_id?: string;
               original_event_id?: string;
+              original_event_private?: boolean;
             }
           | undefined;
 
@@ -1330,7 +1330,7 @@ export function RoomTimeline({
                   : mEvent.getTs(),
               originalRoomId: forwardContent.original_room_id ?? room.roomId,
               originalEventId: forwardContent.original_event_id ?? '',
-              originalEventHidden: forwardContent.original_event_hidden ?? false,
+              originalEventPrivate: forwardContent.original_event_private ?? false,
             }
           : undefined;
 

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -130,7 +130,7 @@ import { useRoomPermissions } from '$hooks/useRoomPermissions';
 import { useGetMemberPowerTag } from '$hooks/useMemberPowerTag';
 import { profilesCacheAtom } from '$state/userRoomProfile';
 import * as css from './RoomTimeline.css';
-import { EncryptedContent, Event, Message, Reactions } from './message';
+import { EncryptedContent, Event, ForwardedMessageProps, Message, Reactions } from './message';
 
 const TimelineFloat = as<'div', css.TimelineFloatVariants>(
   ({ position, className, ...props }, ref) => (
@@ -1311,6 +1311,21 @@ export function RoomTimeline({
         const senderDisplayName =
           getMemberDisplayName(room, senderId, nicknames) ?? getMxIdLocalPart(senderId) ?? senderId;
 
+        // determine if message is forwarded by checking for the presence of the 'moe.sable.message.forward' key in the event content
+        const forwardContent = safeContent['moe.sable.message.forward'] as
+          | { original_timestamp?: unknown }
+          | undefined;
+
+        const messageForwardedProps: ForwardedMessageProps | undefined = forwardContent
+          ? {
+              isForwarded: true,
+              originalTimestamp:
+                typeof forwardContent.original_timestamp === 'number'
+                  ? forwardContent.original_timestamp
+                  : mEvent.getTs(),
+            }
+          : undefined;
+
         return (
           <Message
             key={mEvent.getId()}
@@ -1334,6 +1349,7 @@ export function RoomTimeline({
             onReactionToggle={handleReactionToggle}
             senderId={senderId}
             senderDisplayName={senderDisplayName}
+            messageForwardedProps={messageForwardedProps}
             sendStatus={mEvent.getAssociatedStatus()}
             onResend={handleResend}
             onDeleteFailedSend={handleDeleteFailedSend}

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1313,7 +1313,12 @@ export function RoomTimeline({
 
         // determine if message is forwarded by checking for the presence of the 'moe.sable.message.forward' key in the event content
         const forwardContent = safeContent['moe.sable.message.forward'] as
-          | { original_timestamp?: unknown }
+          | {
+              original_event_hidden: boolean;
+              original_timestamp?: unknown;
+              original_room_id?: string;
+              original_event_id?: string;
+            }
           | undefined;
 
         const messageForwardedProps: ForwardedMessageProps | undefined = forwardContent
@@ -1323,6 +1328,9 @@ export function RoomTimeline({
                 typeof forwardContent.original_timestamp === 'number'
                   ? forwardContent.original_timestamp
                   : mEvent.getTs(),
+              originalRoomId: forwardContent.original_room_id ?? room.roomId,
+              originalEventId: forwardContent.original_event_id ?? '',
+              originalEventHidden: forwardContent.original_event_hidden ?? false,
             }
           : undefined;
 

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -79,6 +79,7 @@ import { MessageForwardItem } from '$components/message/modals/MessageForward';
 import { MessageDeleteItem } from '$components/message/modals/MessageDelete';
 import { MessageReportItem } from '$components/message/modals/MessageReport';
 import { filterPronounsByLanguage } from '$utils/pronouns';
+import { useMentionClickHandler } from '$hooks/useMentionClickHandler';
 import { MessageEditor } from './MessageEditor';
 import * as css from './styles.css';
 
@@ -200,6 +201,9 @@ export const MessagePinItem = as<
 export type ForwardedMessageProps = {
   originalTimestamp: number;
   isForwarded: boolean;
+  originalRoomId: string;
+  originalEventId: string;
+  originalEventHidden: boolean;
 };
 
 export type MessageProps = {
@@ -478,6 +482,8 @@ function MessageInternal(
   const isFailedSend = sendStatus === EventStatus.NOT_SENT;
   const canResend = isFailedSend && senderId === mx.getUserId() && !!onResend;
   const canDeleteFailedSend = isFailedSend && senderId === mx.getUserId() && !!onDeleteFailedSend;
+  // handle clicks on mentions in the message body (e.g. jump to original message from a forwarded message notice)
+  const mentionClickHandler = useMentionClickHandler(room.roomId);
 
   const handleResendClick: MouseEventHandler<HTMLButtonElement> = useCallback(
     (evt) => {
@@ -510,9 +516,24 @@ function MessageInternal(
       })}
     >
       {messageForwardedProps?.isForwarded && (
-        <Chip variant="SurfaceVariant" radii="Pill">
+        <Chip as="div" variant="SurfaceVariant" radii="Pill">
           <Text size="T200" priority="300">
-            Forwarded
+            Forwarded{' '}
+            {messageForwardedProps.originalEventHidden ? 'private message' : 'from another room'}{' '}
+            {!messageForwardedProps.originalEventHidden && (
+              <a
+                href={getMatrixToRoomEvent(
+                  messageForwardedProps.originalRoomId,
+                  messageForwardedProps.originalEventId
+                )}
+                rel="noreferrer noopener"
+                data-mention-id={messageForwardedProps.originalRoomId}
+                data-mention-event-id={messageForwardedProps.originalEventId}
+                onClick={mentionClickHandler}
+              >
+                jump to original
+              </a>
+            )}
             <Time
               ts={messageForwardedProps?.originalTimestamp ?? 0}
               compact={messageLayout === MessageLayout.Compact}

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -75,6 +75,7 @@ import { useBlobCache } from '$hooks/useBlobCache';
 import { MessageAllReactionItem } from '$components/message/modals/MessageReactions';
 import { MessageReadReceiptItem } from '$components/message/modals/MessageReadRecipts';
 import { MessageSourceCodeItem } from '$components/message/modals/MessageSource';
+import { MessageForwardItem } from '$components/message/modals/MessageForward';
 import { MessageDeleteItem } from '$components/message/modals/MessageDelete';
 import { MessageReportItem } from '$components/message/modals/MessageReport';
 import { filterPronounsByLanguage } from '$utils/pronouns';
@@ -150,34 +151,6 @@ export const MessageCopyLinkItem = as<
     >
       <Text className={css.MessageMenuItemText} as="span" size="T300" truncate>
         Copy Link
-      </Text>
-    </MenuItem>
-  );
-});
-
-// MessageForwardItem is for forwarding a message to another room
-export const MessageForwardItem = as<
-  'button',
-  {
-    room: Room;
-    mEvent: MatrixEvent;
-    onClose?: () => void;
-  }
->(({ room, mEvent, onClose, ...props }, ref) => {
-  const mx = useMatrixClient();
-
-  // TODO: replace icon
-  return (
-    <MenuItem
-      size="300"
-      after={<Icon size="100" src={Icons.Pin} />}
-      radii="300"
-      onClick={handleForward}
-      {...props}
-      ref={ref}
-    >
-      <Text className={css.MessageMenuItemText} as="span" size="T300" truncate>
-        Forward Message
       </Text>
     </MenuItem>
   );

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -197,6 +197,11 @@ export const MessagePinItem = as<
   );
 });
 
+export type ForwardedMessageProps = {
+  originalTimestamp: number;
+  isForwarded: boolean;
+};
+
 export type MessageProps = {
   room: Room;
   mEvent: MatrixEvent;
@@ -232,6 +237,7 @@ export type MessageProps = {
   sendStatus?: EventStatus | null;
   onResend?: (event: MatrixEvent) => void;
   onDeleteFailedSend?: (event: MatrixEvent) => void;
+  messageForwardedProps?: ForwardedMessageProps;
 };
 
 function useMobileDoubleTap(callback: () => void, delay = 300) {
@@ -331,6 +337,7 @@ function MessageInternal(
     sendStatus,
     onResend,
     onDeleteFailedSend,
+    messageForwardedProps,
     ...props
   }: MessageProps & { className?: string; children?: ReactNode },
   ref: any
@@ -502,6 +509,20 @@ function MessageInternal(
         [css.MessageFailed]: isFailedSend,
       })}
     >
+      {messageForwardedProps?.isForwarded && (
+        <Chip variant="SurfaceVariant" radii="Pill">
+          <Text size="T200" priority="300">
+            Forwarded
+            <Time
+              ts={messageForwardedProps?.originalTimestamp ?? 0}
+              compact={messageLayout === MessageLayout.Compact}
+              hour24Clock={hour24Clock}
+              dateFormatString={dateFormatString}
+              style={{ marginLeft: config.space.S100 }}
+            />
+          </Text>
+        </Chip>
+      )}
       {reply}
       {edit && onEditId ? (
         <MessageEditor

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -155,6 +155,35 @@ export const MessageCopyLinkItem = as<
   );
 });
 
+// MessageForwardItem is for forwarding a message to another room
+export const MessageForwardItem = as<
+  'button',
+  {
+    room: Room;
+    mEvent: MatrixEvent;
+    onClose?: () => void;
+  }
+>(({ room, mEvent, onClose, ...props }, ref) => {
+  const mx = useMatrixClient();
+
+  // TODO: replace icon
+  return (
+    <MenuItem
+      size="300"
+      after={<Icon size="100" src={Icons.Pin} />}
+      radii="300"
+      onClick={handleForward}
+      {...props}
+      ref={ref}
+    >
+      <Text className={css.MessageMenuItemText} as="span" size="T300" truncate>
+        Forward Message
+      </Text>
+    </MenuItem>
+  );
+});
+
+// message pinning
 export const MessagePinItem = as<
   'button',
   {
@@ -812,6 +841,7 @@ function MessageInternal(
                           <MessageSourceCodeItem room={room} mEvent={mEvent} />
                         )}
                         <MessageCopyLinkItem room={room} mEvent={mEvent} onClose={closeMenu} />
+                        <MessageForwardItem room={room} mEvent={mEvent} onClose={closeMenu} />
                         {canPinEvent && (
                           <MessagePinItem room={room} mEvent={mEvent} onClose={closeMenu} />
                         )}
@@ -1100,6 +1130,7 @@ export const Event = as<'div', EventProps>(
                               <MessageSourceCodeItem room={room} mEvent={mEvent} />
                             )}
                             <MessageCopyLinkItem room={room} mEvent={mEvent} onClose={closeMenu} />
+                            <MessageForwardItem room={room} mEvent={mEvent} onClose={closeMenu} />
                           </Box>
                           {((!mEvent.isRedacted() && canDelete && !stateEvent) ||
                             (mEvent.getSender() !== mx.getUserId() && !stateEvent)) && (

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -539,7 +539,7 @@ function MessageInternal(
               compact={messageLayout === MessageLayout.Compact}
               hour24Clock={hour24Clock}
               dateFormatString={dateFormatString}
-              style={{ marginLeft: config.space.S100 }}
+              style={{ marginLeft: config.space.S100, justifyContent: 'flex-end' }}
             />
           </Text>
         </Chip>

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -203,7 +203,7 @@ export type ForwardedMessageProps = {
   isForwarded: boolean;
   originalRoomId: string;
   originalEventId: string;
-  originalEventHidden: boolean;
+  originalEventPrivate: boolean;
 };
 
 export type MessageProps = {
@@ -519,8 +519,8 @@ function MessageInternal(
         <Chip as="div" variant="SurfaceVariant" radii="Pill">
           <Text size="T200" priority="300">
             Forwarded{' '}
-            {messageForwardedProps.originalEventHidden ? 'private message' : 'from another room'}{' '}
-            {!messageForwardedProps.originalEventHidden && (
+            {messageForwardedProps.originalEventPrivate ? 'private message' : 'from another room'}{' '}
+            {!messageForwardedProps.originalEventPrivate && (
               <a
                 href={getMatrixToRoomEvent(
                   messageForwardedProps.originalRoomId,

--- a/src/app/state/modal.ts
+++ b/src/app/state/modal.ts
@@ -3,6 +3,8 @@ import { MatrixEvent, Room, Relations } from '$types/matrix-sdk';
 
 export enum ModalType {
   Delete = 'delete',
+  // for forwarding a message to another room, not to be confused with the "share" action which is for sharing a message to another app
+  Forward = 'forward',
   Report = 'report',
   Source = 'source',
   Reactions = 'reactions',
@@ -11,6 +13,7 @@ export enum ModalType {
 
 export type ModalState =
   | { type: ModalType.Delete; room: Room; mEvent: MatrixEvent }
+  | { type: ModalType.Forward; room: Room; mEvent: MatrixEvent }
   | { type: ModalType.Report; room: Room; mEvent: MatrixEvent }
   | { type: ModalType.Source; room: Room; mEvent: MatrixEvent }
   | { type: ModalType.Reactions; room: Room; relations: Relations }


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

added the possibility to forward a message. the forwarded message also contains metadate about the original message in (if the original message was sent in a public room)

Current limitation: you can only forward it to one room at a time. Possibly missing is also a confirmation for successful forwarding.

#### How forwarding looks like

<img width="177" height="405" alt="image" src="https://github.com/user-attachments/assets/85323e3d-333a-41e5-80af-682f6f5cb0fd" />
<img width="255" height="354" alt="image" src="https://github.com/user-attachments/assets/140e9542-ac04-4a3f-b925-17687f1d3349" />


#### How the forwarded message looks

##### On Sable

<img width="533" height="87" alt="image" src="https://github.com/user-attachments/assets/672994b4-1f9d-4940-8fa1-ea0a7a1fffbe" />

#### On Element for example

<img width="627" height="85" alt="image" src="https://github.com/user-attachments/assets/8b7bb90f-c49c-4d1d-96c5-65791592b36c" />

For clients other than sable it is wrapped in a blockquote with a descriptive heading in front of it. For sable this gets striped.

Fixes https://github.com/7w1/sable/issues/202

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
