### PR TITLE
fix(commands): /myroomnick without new nick resets nick

### DIFF
--- a/.changeset/pr207-myroomnick-unset.md
+++ b/.changeset/pr207-myroomnick-unset.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Executing /myroomnick without a new nickname now removes the nickname.

--- a/.changeset/pr207-myroomnick-unset.md
+++ b/.changeset/pr207-myroomnick-unset.md
@@ -2,4 +2,4 @@
 sable: patch
 ---
 
-Executing /myroomnick without a new nickname now removes the nickname.
+Executing /myroomnick or /myroomavatar without a new nickname/avatar now removes the nickname/avatar.

--- a/src/app/hooks/useCommands.ts
+++ b/src/app/hooks/useCommands.ts
@@ -33,6 +33,7 @@ import { createRoomEncryptionState } from '$components/create-room';
 import { parsePronounsInput } from '$utils/pronouns';
 import { useRoomNavigate } from './useRoomNavigate';
 import { enrichWidgetUrl } from './useRoomWidgets';
+import { useUserProfile } from './useUserProfile';
 
 export const SHRUG = '¯\\_(ツ)_/¯';
 export const TABLEFLIP = '(╯°□°)╯︵ ┻━┻';
@@ -253,6 +254,7 @@ export type CommandRecord = Record<Command, CommandContent>;
 export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
   const { navigateRoom } = useRoomNavigate();
   const [developerTools] = useSetting(settingsAtom, 'developerTools');
+  const profile = useUserProfile(mx.getSafeUserId());
 
   const commands: CommandRecord = useMemo(
     () => ({
@@ -439,8 +441,8 @@ export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
         name: Command.MyRoomNick,
         description: 'Change nick in current room.',
         exe: async (payload) => {
-          const nick = payload.trim();
-          if (nick === '') return;
+          let nick: string | null = payload.trim();
+          if (nick === '') nick = profile.displayName ?? null;
           const mEvent = room
             .getLiveTimeline()
             .getState(EventTimeline.FORWARDS)
@@ -1288,7 +1290,7 @@ export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
         },
       },
     }),
-    [mx, room, navigateRoom, developerTools]
+    [mx, navigateRoom, room, profile.displayName, profile.avatarUrl, developerTools]
   );
 
   return commands;

--- a/src/app/hooks/useCommands.ts
+++ b/src/app/hooks/useCommands.ts
@@ -464,23 +464,29 @@ export const useCommands = (mx: MatrixClient, room: Room): CommandRecord => {
         name: Command.MyRoomAvatar,
         description: 'Change profile picture in current room. Example /myroomavatar mxc://xyzabc',
         exe: async (payload) => {
-          if (payload.match(/^mxc:\/\/\S+$/)) {
-            const mEvent = room
-              .getLiveTimeline()
-              .getState(EventTimeline.FORWARDS)
-              ?.getStateEvents(StateEvent.RoomMember, mx.getSafeUserId());
-            const content = mEvent?.getContent();
-            if (!content) return;
-            await mx.sendStateEvent(
-              room.roomId,
-              StateEvent.RoomMember as any,
-              {
-                ...content,
-                avatar_url: payload,
-              },
-              mx.getSafeUserId()
-            );
+          let newAvatar: string | undefined = payload.trim();
+          if (newAvatar.length === 0) {
+            // no avatar, reset to global
+            newAvatar = profile.avatarUrl;
+          } else if (!newAvatar.match(/^mxc:\/\/\S+$/)) {
+            // bad mxc
+            return;
           }
+          const mEvent = room
+            .getLiveTimeline()
+            .getState(EventTimeline.FORWARDS)
+            ?.getStateEvents(StateEvent.RoomMember, mx.getSafeUserId());
+          const content = mEvent?.getContent();
+          if (!content) return;
+          await mx.sendStateEvent(
+            room.roomId,
+            StateEvent.RoomMember as any,
+            {
+              ...content,
+              avatar_url: newAvatar,
+            },
+            mx.getSafeUserId()
+          );
         },
       },
       [Command.ConvertToDm]: {


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

previously running /myroomnick without a new nick would silently ignore your command
now it sets your nick to the global display name
same change applied to /myroomavatar

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
