### PR TITLE
ci(docker): build site once and package per-arch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules/
+dist/
 .git/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,15 +62,29 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.release_tag.outputs.value }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
             type=semver,pattern={{major}},value=${{ steps.release_tag.outputs.value }},enable=${{ steps.release_tag.outputs.is_release == 'true' && !startsWith(steps.release_tag.outputs.value, 'v0.') }}
 
+      - name: Compute short SHA
+        id: vars
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Build site
+        env:
+          VITE_BUILD_HASH: ${{ steps.vars.outputs.short_sha }}
+          VITE_IS_RELEASE_TAG: ${{ steps.release_tag.outputs.is_release }}
+        run: |
+          npm ci --ignore-scripts
+          NODE_OPTIONS=--max_old_space_size=4096 npm run build
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-      - name: Compute short SHA
-        id: vars
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
         id: push
@@ -83,9 +97,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            VITE_BUILD_HASH=${{ steps.vars.outputs.short_sha }}
-            VITE_IS_RELEASE_TAG=${{ steps.release_tag.outputs.is_release }}
+          build-contexts: |
+            site-dist=./dist
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,15 @@ COPY . /src/
 ENV NODE_OPTIONS=--max_old_space_size=4096
 RUN npm run build
 
+## Dist
+FROM scratch AS site-dist
+COPY --from=builder /src/dist /
 
 ## App
 FROM nginx:1.29.5-alpine
 
-COPY --from=builder /src/dist /app
-COPY --from=builder /src/docker-nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=site-dist / /app
+COPY docker-nginx.conf /etc/nginx/conf.d/default.conf
 
 RUN rm -rf /usr/share/nginx/html \
-  && ln -s /app /usr/share/nginx/html
+    && ln -s /app /usr/share/nginx/html


### PR DESCRIPTION
### Description

The multi-arch Docker build previously ran `npm ci` + `npm run build` for each target platform (amd64, arm64) despite producing identical static assets.

This PR adds an overridable `site-dist` intermediate stage to the Dockerfile. In CI, `--build-context site-dist=./dist` replaces this stage with the pre-built output, causing BuildKit to skip the entire Node.js builder stage. The workflow now builds the site once natively on the runner, then the multi-arch step only packages the pre-built dist into nginx.

Local `docker build .` continues to work unchanged, with the builder stage running as before when no override is provided.

#### How it works

| | Local `docker build .` | CI (`--build-context site-dist=./dist`) |
|---|---|---|
| **Builder stage** | Runs `npm ci` + `npm run build` | Skipped entirely |
| **site-dist stage** | Extracts `dist/` from builder | Replaced by pre-built `./dist/` |
| **App stage** | Packages into nginx | Packages into nginx (per-arch) |

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings