### PR TITLE
Change indexdb warning to include low disk space as reason

### DIFF
--- a/.changeset/change_indexdb_warning.md
+++ b/.changeset/change_indexdb_warning.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+change indexdb warning phrasing to include low disk space as possible reason

--- a/src/app/pages/FeatureCheck.tsx
+++ b/src/app/pages/FeatureCheck.tsx
@@ -19,8 +19,12 @@ export function FeatureCheck({ children }: { children: ReactNode }) {
             <Box style={{ padding: config.space.S400 }} direction="Column" gap="400">
               <Text>Missing Browser Feature</Text>
               <Text size="T300" priority="400">
-                No IndexedDB support found. This application requires IndexedDB to store session
-                data locally. Please make sure your browser support IndexedDB and have it enabled.
+                This application needs a feature called IndexedDB to save your session data on your
+                device. It looks like your browser either doesn&apos;t support IndexedDB or it
+                isn&apos;t working properly right now. Please make sure your browser supports
+                IndexedDB and that it&apos;s enabled. If your browser does support IndexedDB, try
+                restarting your browser or checking your browser settings to ensure it&apos;s
+                working correctly.
               </Text>
               <Text size="T200">
                 <a

--- a/src/app/pages/FeatureCheck.tsx
+++ b/src/app/pages/FeatureCheck.tsx
@@ -11,7 +11,7 @@ export function FeatureCheck({ children }: { children: ReactNode }) {
     checkIDBSupport();
   }, [checkIDBSupport]);
 
-  if (idbSupportState.status === AsyncStatus.Success && idbSupportState.data === true) {
+  if (idbSupportState.status === AsyncStatus.Success && idbSupportState.data === false) {
     return (
       <SplashScreen>
         <Box grow="Yes" alignItems="Center" justifyContent="Center">

--- a/src/app/pages/FeatureCheck.tsx
+++ b/src/app/pages/FeatureCheck.tsx
@@ -11,7 +11,7 @@ export function FeatureCheck({ children }: { children: ReactNode }) {
     checkIDBSupport();
   }, [checkIDBSupport]);
 
-  if (idbSupportState.status === AsyncStatus.Success && idbSupportState.data === false) {
+  if (idbSupportState.status === AsyncStatus.Success && idbSupportState.data === true) {
     return (
       <SplashScreen>
         <Box grow="Yes" alignItems="Center" justifyContent="Center">
@@ -19,11 +19,10 @@ export function FeatureCheck({ children }: { children: ReactNode }) {
             <Box style={{ padding: config.space.S400 }} direction="Column" gap="400">
               <Text>Missing Browser Feature</Text>
               <Text size="T300" priority="400">
-                This application needs a feature called IndexedDB to save your session data on your
-                device. It looks like your browser either doesn&apos;t support IndexedDB or it
-                isn&apos;t working properly right now. Make sure your browser supports IndexedDB and
-                that it&apos;s enabled. Please also check if you have enough free disk space, as
-                IndexedDB may not work properly if your device is running low on storage.
+                This app needs IndexedDB to save sessions, but your browser doesn&apos;t support it
+                or it&apos;s disabled. Please ensure IndexedDB is enabled, restart your browser,
+                check settings/extensions or privacy mode, free up disk space, or try updating/using
+                another browser.
               </Text>
               <Text size="T200">
                 <a

--- a/src/app/pages/FeatureCheck.tsx
+++ b/src/app/pages/FeatureCheck.tsx
@@ -21,10 +21,9 @@ export function FeatureCheck({ children }: { children: ReactNode }) {
               <Text size="T300" priority="400">
                 This application needs a feature called IndexedDB to save your session data on your
                 device. It looks like your browser either doesn&apos;t support IndexedDB or it
-                isn&apos;t working properly right now. Please make sure your browser supports
-                IndexedDB and that it&apos;s enabled. If your browser does support IndexedDB, try
-                restarting your browser or checking your browser settings to ensure it&apos;s
-                working correctly.
+                isn&apos;t working properly right now. Make sure your browser supports IndexedDB and
+                that it&apos;s enabled. Please also check if you have enough free disk space, as
+                IndexedDB may not work properly if your device is running low on storage.
               </Text>
               <Text size="T200">
                 <a


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Change IndexedDB warning to include the possibility of running out of space as a reason for IndexedDB not working.

Todo for another day, maybe, finding a way to check if it really is because out of storage - didn't find a good way that didn't crash the browser 

Alternatives considered:

- testing by writing a blob into a test IndexedDB which resulted in the browser crashing if out of disk space
- using `navigator.storage.estimate()`… however, this doesn't return any useful information. in my test it returned 

```
quota: 296630877388
usage: 292979
```

and i definitely didn't had 296,630877388 GB of free space 

Fixes https://github.com/7w1/sable/issues/209

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
