### PR TITLE
fix: use port 8080 instead of 80 in Caddyfile

### DIFF
--- a/.changeset/caddy_port_8080.md
+++ b/.changeset/caddy_port_8080.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Fix Caddyfile to listen on port 8080 instead of 80. The container runs with `--cap-drop=ALL`, which removes `CAP_NET_BIND_SERVICE`, making privileged ports (<1024) unavailable.

--- a/.changeset/caddy_port_8080.md
+++ b/.changeset/caddy_port_8080.md
@@ -2,4 +2,10 @@
 sable: patch
 ---
 
-Fix Caddyfile to listen on port 8080 instead of 80. Deployment methods such as matrix-docker-ansible-deploy run the container with `--cap-drop=ALL`, which removes `CAP_NET_BIND_SERVICE` and makes privileged ports (<1024) unavailable. Beyond that specific constraint, binding directly to low-numbered ports inside a container is generally discouraged — production deployments are expected to sit behind a reverse proxy (e.g. Traefik, nginx) that handles port 80/443 externally.
+Fix container startup failure under hardened deployments (e.g. matrix-docker-ansible-deploy) that run with `--cap-drop=ALL` and `--read-only`.
+
+Two issues were present:
+
+1. `caddy:2-alpine` sets `cap_net_bind_service=+ep` as a file capability on `/usr/bin/caddy`. With an empty bounding capability set (`--cap-drop=ALL`), the kernel refuses to exec the binary entirely, producing `exec /usr/bin/caddy: operation not permitted`. Fixed by stripping the file capability in the Dockerfile (`setcap -r /usr/bin/caddy`).
+
+2. The Caddyfile was listening on `:80`, which is a privileged port. The container runs as a non-root user and with `CAP_NET_BIND_SERVICE` dropped, so port 80 is unavailable. Beyond that constraint, binding to low-numbered ports inside a container is generally discouraged — production deployments sit behind a reverse proxy that handles 80/443 externally. Fixed by changing the Caddyfile to listen on `:8080`.

--- a/.changeset/caddy_port_8080.md
+++ b/.changeset/caddy_port_8080.md
@@ -2,4 +2,4 @@
 sable: patch
 ---
 
-Fix Caddyfile to listen on port 8080 instead of 80. The container runs with `--cap-drop=ALL`, which removes `CAP_NET_BIND_SERVICE`, making privileged ports (<1024) unavailable.
+Fix Caddyfile to listen on port 8080 instead of 80. Deployment methods such as matrix-docker-ansible-deploy run the container with `--cap-drop=ALL`, which removes `CAP_NET_BIND_SERVICE` and makes privileged ports (<1024) unavailable. Beyond that specific constraint, binding directly to low-numbered ports inside a container is generally discouraged — production deployments are expected to sit behind a reverse proxy (e.g. Traefik, nginx) that handles port 80/443 externally.

--- a/Caddyfile
+++ b/Caddyfile
@@ -4,7 +4,7 @@
 	}
 }
 
-:80 {
+:8080 {
 	root * /app
 
 	# Enable on-the-fly compression for things not pre-compressed

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,11 @@ COPY --from=builder /src/dist /
 ## App
 FROM caddy:2-alpine
 
+# Strip the file capability set by the base image (cap_net_bind_service=+ep).
+# With --cap-drop=ALL the bounding set is empty, and the kernel refuses to exec
+# any binary that has file capabilities not present in the bounding set — even
+# if those capabilities aren't actually needed at runtime (we listen on :8080).
+RUN setcap -r /usr/bin/caddy
+
 COPY --from=site-dist / /app
 COPY Caddyfile /etc/caddy/Caddyfile


### PR DESCRIPTION
## Problem

Port 80 is unavailable inside the container for several compounding reasons:

1. **Running non-root** — the container runs as an unprivileged user (`--user=999:987`), which alone prevents binding to privileged ports (<1024) on most Linux configurations.
2. **`--cap-drop=ALL`** — deployment methods such as [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy) run the container with all capabilities dropped, explicitly removing `CAP_NET_BIND_SERVICE`. Even if the kernel were otherwise configured to allow non-root low-port binding, this capability drop prevents it.
3. **Best practice** — even where technically possible, binding directly to port 80/443 inside a container is generally discouraged. Production deployments are expected to sit behind a reverse proxy (e.g. Traefik, nginx) that handles those ports externally.

There is an additional, separate issue: `caddy:2-alpine` sets `cap_net_bind_service=+ep` as a **file capability** on `/usr/bin/caddy` so it can bind port 80 as non-root. With `--cap-drop=ALL`, the bounding capability set is empty. The Linux kernel refuses to `execve` any binary whose file capability set is not a subset of the bounding set, resulting in:

```
exec /usr/bin/caddy: operation not permitted
```

This means the container fails to start entirely, even without any port conflict.

## Solution

1. Change the Caddyfile to listen on `:8080` instead of `:80`.
2. Strip the file capability from the caddy binary in the Dockerfile (`setcap -r /usr/bin/caddy`) so it can be executed under `--cap-drop=ALL`.

## Changes

- `Caddyfile`: `:80` → `:8080`
- `Dockerfile`: add `RUN setcap -r /usr/bin/caddy` after the `caddy:2-alpine` base stage