### PR TITLE
Fix picture in picture setting not effecting element-call

### DIFF
--- a/.changeset/fix_picture_in_picture_setting_not_effecting_element_call.md
+++ b/.changeset/fix_picture_in_picture_setting_not_effecting_element_call.md
@@ -1,0 +1,5 @@
+---
+sable: minor
+---
+
+# Fix picture in picture setting not effecting element-call

--- a/.changeset/fix_picture_in_picture_setting_not_effecting_element_call.md
+++ b/.changeset/fix_picture_in_picture_setting_not_effecting_element_call.md
@@ -1,5 +1,5 @@
 ---
-sable: minor
+sable: patch
 ---
 
-# Fix picture in picture setting not effecting element-call
+Fix picture in picture setting not effecting element-call

--- a/src/app/hooks/useCallEmbed.ts
+++ b/src/app/hooks/useCallEmbed.ts
@@ -2,6 +2,8 @@ import { createContext, RefObject, useCallback, useContext, useEffect, useState 
 import { MatrixRTCSession } from 'matrix-js-sdk/lib/matrixrtc/MatrixRTCSession';
 import { MatrixClient, Room } from 'matrix-js-sdk';
 import { useSetAtom } from 'jotai';
+import { settingsAtom } from '$state/settings';
+import { useSetting } from '$state/hooks/settings';
 import {
   CallEmbed,
   ElementCallThemeKind,
@@ -77,6 +79,19 @@ export const useCallStart = (dm = false) => {
 
 export const useCallJoined = (embed?: CallEmbed): boolean => {
   const [joined, setJoined] = useState(embed?.joined ?? false);
+  const [allowPip] = useSetting(settingsAtom, 'allowPipVideos');
+
+  if (embed && allowPip) {
+    const removeDisablePictureInPicture = (mutated: any) => {
+      mutated.forEach((event: any) => {
+        Array.from(event.target.getElementsByTagName('video')).forEach((video: any) => {
+          video.removeAttribute('disablepictureinpicture');
+        });
+      });
+    };
+    const pipObserver = new MutationObserver(removeDisablePictureInPicture);
+    pipObserver.observe(embed.iframe.contentDocument!, { subtree: true, childList: true });
+  }
 
   useClientWidgetApiEvent(
     embed?.call,


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Merging Cinny's Element-Call changes removed the previous code that injected a mutation watcher to remove `displayPictureInPicture` from the `video` elements.


<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
