### PR TITLE
feat: notification settings page improvements

### DIFF
--- a/.changeset/feat-notification-settings-ui.md
+++ b/.changeset/feat-notification-settings-ui.md
@@ -1,0 +1,14 @@
+---
+sable: minor
+---
+
+feat: notification settings page improvements
+
+- Rename "Mobile In-App Notifications" → "In-App Notifications"; show the toggle on all platforms.
+- Rename "Notification Sound" → "In-App Notification Sound" to clarify it only controls in-page audio, not push sound.
+- Move badge display settings (Show Unread Counts, Badge Counts for DMs Only, Show Unread Ping Counts) from Appearance into the Notifications page.
+- Fix "System Notifications" description — remove incorrect claim that mobile uses the in-app banner instead.
+- Add a notification levels info button (ⓘ) to the All Messages, Special Messages, and Keyword Messages section headings explaining Disable / Notify Silent / Notify Loud.
+- Add descriptive text under each notification section heading.
+- Collapse the two `@room` push rules into a single "Mention @room" control (routes to `IsRoomMention` on modern servers, `AtRoomNotification` on older servers). Showing them separately caused an apparent sync loop where setting one immediately reset the other.
+- Add "Follows your global notification rules" subtitle to the "Default" option in the per-room notification switcher.

--- a/src/app/components/RoomNotificationSwitcher.tsx
+++ b/src/app/components/RoomNotificationSwitcher.tsx
@@ -104,9 +104,16 @@ export function RoomNotificationModeSwitcher({
                     />
                   }
                 >
-                  <Text size="T300">
-                    {mode === value ? <b>{modeToStr[mode]}</b> : modeToStr[mode]}
-                  </Text>
+                  <Box direction="Column" gap="100">
+                    <Text size="T300">
+                      {mode === value ? <b>{modeToStr[mode]}</b> : modeToStr[mode]}
+                    </Text>
+                    {mode === RoomNotificationMode.Unset && (
+                      <Text size="T200" priority="300">
+                        Follows your global notification rules
+                      </Text>
+                    )}
+                  </Box>
                 </MenuItem>
               ))}
             </Box>

--- a/src/app/features/settings/cosmetics/Themes.tsx
+++ b/src/app/features/settings/cosmetics/Themes.tsx
@@ -388,9 +388,6 @@ function PageZoomInput() {
 }
 export function Appearance() {
   const [twitterEmoji, setTwitterEmoji] = useSetting(settingsAtom, 'twitterEmoji');
-  const [showUnreadCounts, setShowUnreadCounts] = useSetting(settingsAtom, 'showUnreadCounts');
-  const [badgeCountDMsOnly, setBadgeCountDMsOnly] = useSetting(settingsAtom, 'badgeCountDMsOnly');
-  const [showPingCounts, setShowPingCounts] = useSetting(settingsAtom, 'showPingCounts');
 
   return (
     <Box direction="Column" gap="700">
@@ -409,31 +406,6 @@ export function Appearance() {
 
         <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
           <SettingTile title="Page Zoom" after={<PageZoomInput />} />
-        </SequenceCard>
-        <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
-          <SettingTile
-            title="Show Unread Counts"
-            description="Display the number of unread messages on room and sidebar badges."
-            after={
-              <Switch variant="Primary" value={showUnreadCounts} onChange={setShowUnreadCounts} />
-            }
-          />
-        </SequenceCard>
-        <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
-          <SettingTile
-            title="Badge Counts for DMs Only"
-            description="Only show unread counts on Direct Message badges. Non-DM rooms and spaces show a plain dot instead."
-            after={
-              <Switch variant="Primary" value={badgeCountDMsOnly} onChange={setBadgeCountDMsOnly} />
-            }
-          />
-        </SequenceCard>
-        <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
-          <SettingTile
-            title="Show Unread Ping Counts"
-            description="When enabled overrides Show Unread Counts to still display counts."
-            after={<Switch variant="Primary" value={showPingCounts} onChange={setShowPingCounts} />}
-          />
         </SequenceCard>
       </Box>
     </Box>

--- a/src/app/features/settings/notifications/AllMessages.tsx
+++ b/src/app/features/settings/notifications/AllMessages.tsx
@@ -20,6 +20,7 @@ import {
 import { useMatrixClient } from '$hooks/useMatrixClient';
 import { SequenceCardStyle } from '$features/settings/styles.css';
 import { NotificationModeSwitcher } from './NotificationModeSwitcher';
+import { NotificationLevelsHint } from './NotificationLevelsHint';
 
 const getAllMessageDefaultRule = (
   ruleId: RuleId,
@@ -89,13 +90,17 @@ export function AllMessagesNotifications() {
     <Box direction="Column" gap="100">
       <Box alignItems="Center" justifyContent="SpaceBetween" gap="200">
         <Text size="L400">All Messages</Text>
-        <Box gap="100">
+        <Box gap="100" alignItems="Center">
+          <NotificationLevelsHint />
           <Text size="T200">Badge: </Text>
           <Badge radii="300" variant="Secondary" fill="Solid">
             <Text size="L400">1</Text>
           </Badge>
         </Box>
       </Box>
+      <Text size="T300" priority="300">
+        Default notification level for all messages in rooms where no per-room override is set.
+      </Text>
       <SequenceCard
         className={SequenceCardStyle}
         variant="SurfaceVariant"

--- a/src/app/features/settings/notifications/KeywordMessages.tsx
+++ b/src/app/features/settings/notifications/KeywordMessages.tsx
@@ -15,6 +15,7 @@ import {
 import { AsyncStatus, useAsyncCallback } from '$hooks/useAsyncCallback';
 import { SequenceCardStyle } from '$features/settings/styles.css';
 import { NotificationModeSwitcher } from './NotificationModeSwitcher';
+import { NotificationLevelsHint } from './NotificationLevelsHint';
 
 const NOTIFY_MODE_OPS: NotificationModeOptions = {
   highlight: true,
@@ -163,13 +164,17 @@ export function KeywordMessagesNotifications() {
     <Box direction="Column" gap="100">
       <Box alignItems="Center" justifyContent="SpaceBetween" gap="200">
         <Text size="L400">Keyword Messages</Text>
-        <Box gap="100">
+        <Box gap="100" alignItems="Center">
+          <NotificationLevelsHint />
           <Text size="T200">Badge: </Text>
           <Badge radii="300" variant="Success" fill="Solid">
             <Text size="L400">1</Text>
           </Badge>
         </Box>
       </Box>
+      <Text size="T300" priority="300">
+        Custom keywords that trigger notifications when matched in a message body.
+      </Text>
       <SequenceCard
         className={SequenceCardStyle}
         variant="SurfaceVariant"

--- a/src/app/features/settings/notifications/NotificationLevelsHint.tsx
+++ b/src/app/features/settings/notifications/NotificationLevelsHint.tsx
@@ -1,0 +1,70 @@
+import { MouseEventHandler, useState } from 'react';
+import { Box, config, Header, Icon, IconButton, Icons, Menu, PopOut, RectCords, Text } from 'folds';
+import FocusTrap from 'focus-trap-react';
+import { stopPropagation } from '$utils/keyboard';
+
+export function NotificationLevelsHint() {
+  const [anchor, setAnchor] = useState<RectCords>();
+
+  const handleOpen: MouseEventHandler<HTMLElement> = (evt) => {
+    setAnchor(evt.currentTarget.getBoundingClientRect());
+  };
+
+  const itemPadding = { padding: config.space.S200, paddingTop: 0 };
+
+  return (
+    <PopOut
+      anchor={anchor}
+      position="Bottom"
+      align="End"
+      content={
+        <FocusTrap
+          focusTrapOptions={{
+            initialFocus: false,
+            onDeactivate: () => setAnchor(undefined),
+            clickOutsideDeactivates: true,
+            escapeDeactivates: stopPropagation,
+          }}
+        >
+          <Menu style={{ maxWidth: '280px' }}>
+            <Header size="300" style={{ padding: `0 ${config.space.S200}` }}>
+              <Text size="L400">Notification Levels</Text>
+            </Header>
+            <Box direction="Column" style={itemPadding} gap="300" tabIndex={0}>
+              <Box direction="Column" gap="100">
+                <Text size="L400">Disable</Text>
+                <Text size="T300" priority="300">
+                  The rule is muted. No notifications of any kind.
+                </Text>
+              </Box>
+              <Box direction="Column" gap="100">
+                <Text size="L400">Notify Silent</Text>
+                <Text size="T300" priority="300">
+                  Visual notification (badge and banner) when a relevant message arrives. No sound.
+                </Text>
+              </Box>
+              <Box direction="Column" gap="100">
+                <Text size="L400">Notify Loud</Text>
+                <Text size="T300" priority="300">
+                  Visual highlight plus sound. Respects the Notification Sound setting above, and
+                  triggers sound and vibration on mobile push.
+                </Text>
+              </Box>
+            </Box>
+          </Menu>
+        </FocusTrap>
+      }
+    >
+      <IconButton
+        onClick={handleOpen}
+        type="button"
+        variant="Secondary"
+        size="300"
+        radii="300"
+        aria-pressed={!!anchor}
+      >
+        <Icon style={{ opacity: config.opacity.P300 }} size="100" src={Icons.Info} />
+      </IconButton>
+    </PopOut>
+  );
+}

--- a/src/app/features/settings/notifications/SpecialMessages.tsx
+++ b/src/app/features/settings/notifications/SpecialMessages.tsx
@@ -17,6 +17,7 @@ import {
 } from '$hooks/useNotificationMode';
 import { SequenceCardStyle } from '$features/settings/styles.css';
 import { NotificationModeSwitcher } from './NotificationModeSwitcher';
+import { NotificationLevelsHint } from './NotificationLevelsHint';
 
 const NOTIFY_MODE_OPS: NotificationModeOptions = {
   highlight: true,
@@ -120,18 +121,23 @@ export function SpecialMessagesNotifications() {
     () => pushRulesEvt?.getContent<IPushRules>() ?? { global: {} },
     [pushRulesEvt]
   );
+  const intentionalMentions = mx.supportsIntentionalMentions();
 
   return (
     <Box direction="Column" gap="100">
       <Box alignItems="Center" justifyContent="SpaceBetween" gap="200">
         <Text size="L400">Special Messages</Text>
-        <Box gap="100">
+        <Box gap="100" alignItems="Center">
+          <NotificationLevelsHint />
           <Text size="T200">Badge: </Text>
           <Badge radii="300" variant="Success" fill="Solid">
             <Text size="L400">1</Text>
           </Badge>
         </Box>
       </Box>
+      <Text size="T300" priority="300">
+        Overrides the All Messages level for messages that mention you or match a keyword.
+      </Text>
       <SequenceCard
         className={SequenceCardStyle}
         variant="SurfaceVariant"
@@ -191,29 +197,21 @@ export function SpecialMessagesNotifications() {
       >
         <SettingTile
           title="Mention @room"
+          description="Only triggers if the sender has permission to notify the whole room."
           after={
-            <MentionModeSwitcher
-              pushRules={pushRules}
-              ruleId={RuleId.IsRoomMention}
-              defaultPushRuleData={DefaultIsRoomMention}
-            />
-          }
-        />
-      </SequenceCard>
-      <SequenceCard
-        className={SequenceCardStyle}
-        variant="SurfaceVariant"
-        direction="Column"
-        gap="400"
-      >
-        <SettingTile
-          title="Contains @room"
-          after={
-            <MentionModeSwitcher
-              pushRules={pushRules}
-              ruleId={RuleId.AtRoomNotification}
-              defaultPushRuleData={DefaultAtRoomNotification}
-            />
+            intentionalMentions ? (
+              <MentionModeSwitcher
+                pushRules={pushRules}
+                ruleId={RuleId.IsRoomMention}
+                defaultPushRuleData={DefaultIsRoomMention}
+              />
+            ) : (
+              <MentionModeSwitcher
+                pushRules={pushRules}
+                ruleId={RuleId.AtRoomNotification}
+                defaultPushRuleData={DefaultAtRoomNotification}
+              />
+            )
           }
         />
       </SequenceCard>

--- a/src/app/features/settings/notifications/SystemNotification.tsx
+++ b/src/app/features/settings/notifications/SystemNotification.tsx
@@ -186,24 +186,39 @@ export function SystemNotification() {
     settingsAtom,
     'clearNotificationsOnRead'
   );
+  const [showUnreadCounts, setShowUnreadCounts] = useSetting(settingsAtom, 'showUnreadCounts');
+  const [badgeCountDMsOnly, setBadgeCountDMsOnly] = useSetting(settingsAtom, 'badgeCountDMsOnly');
+  const [showPingCounts, setShowPingCounts] = useSetting(settingsAtom, 'showPingCounts');
+
+  // Describe what the current badge combo actually does so users aren't left guessing.
+  const badgeBehaviourSummary = (): string => {
+    if (!showUnreadCounts && !showPingCounts) {
+      return 'Badges show a plain dot for any unread activity — no numbers displayed.';
+    }
+    if (!showUnreadCounts && showPingCounts) {
+      return 'Badges show a number only when you are directly mentioned; all other unread activity shows a plain dot.';
+    }
+    if (showUnreadCounts && badgeCountDMsOnly) {
+      return 'Only Direct Message badges show a number count. Rooms and spaces show a plain dot instead.';
+    }
+    return 'All rooms and DMs show a number count for every unread message.';
+  };
 
   return (
     <Box direction="Column" gap="100">
       <Text size="L400">System & Notifications</Text>
-      {mobileOrTablet() && (
-        <SequenceCard
-          className={SequenceCardStyle}
-          variant="SurfaceVariant"
-          direction="Column"
-          gap="400"
-        >
-          <SettingTile
-            title="Mobile In-App Notifications"
-            description="Show a notification banner inside the app when a message arrives."
-            after={<Switch value={showInAppNotifs} onChange={setShowInAppNotifs} />}
-          />
-        </SequenceCard>
-      )}
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="400"
+      >
+        <SettingTile
+          title="In-App Notifications"
+          description="Show a notification banner inside the app when a message arrives."
+          after={<Switch value={showInAppNotifs} onChange={setShowInAppNotifs} />}
+        />
+      </SequenceCard>
       {mobileOrTablet() && (
         <SequenceCard
           className={SequenceCardStyle}
@@ -223,11 +238,23 @@ export function SystemNotification() {
         >
           <SettingTile
             title="System Notifications"
-            description="Show an OS-level notification banner when a message arrives while the app is open. On mobile, the in-app banner is used instead."
+            description="Show an OS-level notification banner when a message arrives while the app is open."
             after={<Switch value={showSystemNotifs} onChange={setShowSystemNotifs} />}
           />
         </SequenceCard>
       )}
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="400"
+      >
+        <SettingTile
+          title="In-App Notification Sound"
+          description="Play a sound inside the app when a new message arrives."
+          after={<Switch value={isNotificationSounds} onChange={setIsNotificationSounds} />}
+        />
+      </SequenceCard>
       <SequenceCard
         className={SequenceCardStyle}
         variant="SurfaceVariant"
@@ -276,18 +303,6 @@ export function SystemNotification() {
         direction="Column"
         gap="400"
       >
-        <SettingTile
-          title="Notification Sound"
-          description="Play sound when new message arrives and app is open."
-          after={<Switch value={isNotificationSounds} onChange={setIsNotificationSounds} />}
-        />
-      </SequenceCard>
-      <SequenceCard
-        className={SequenceCardStyle}
-        variant="SurfaceVariant"
-        direction="Column"
-        gap="400"
-      >
         <EmailNotification />
       </SequenceCard>
 
@@ -298,6 +313,56 @@ export function SystemNotification() {
         gap="400"
       >
         <DeregisterAllPushersSetting />
+      </SequenceCard>
+
+      <Text size="L400">Badges</Text>
+      <Text size="T300" style={{ opacity: 0.7 }}>
+        {badgeBehaviourSummary()}
+      </Text>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="400"
+      >
+        <SettingTile
+          title="Show Message Counts"
+          description="Show a number on room, space, and DM badges for every unread message."
+          after={
+            <Switch variant="Primary" value={showUnreadCounts} onChange={setShowUnreadCounts} />
+          }
+        />
+      </SequenceCard>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="400"
+      >
+        <SettingTile
+          title="Direct Messages Only"
+          description="Only DM badges display a count. Room and space badges show a plain dot instead."
+          after={
+            <Switch
+              variant="Primary"
+              value={badgeCountDMsOnly}
+              onChange={setBadgeCountDMsOnly}
+              disabled={!showUnreadCounts}
+            />
+          }
+        />
+      </SequenceCard>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="400"
+      >
+        <SettingTile
+          title="Always Count Mentions"
+          description="Show a number on any badge where you were directly mentioned, even if message counts are turned off."
+          after={<Switch variant="Primary" value={showPingCounts} onChange={setShowPingCounts} />}
+        />
       </SequenceCard>
     </Box>
   );


### PR DESCRIPTION
## Summary

Improves the Notifications settings page and the per-room notification switcher. No behaviour changes — purely UI/labelling improvements.

## Changes

- **Rename "Mobile In-App Notifications" → "In-App Notifications"** — show the toggle on all platforms (was mobile-only; the underlying feature now works everywhere).
- **Rename "Notification Sound" → "In-App Notification Sound"** — clarifies it only controls the in-page audio tone, not push sound.
- **Move badge settings to Notifications** — "Show Unread Counts", "Badge Counts for DMs Only", and "Show Unread Ping Counts" moved from Appearance to Notifications, where they belong.
- **Fix "System Notifications" description** — remove incorrect claim that mobile shows the in-app banner instead of system notifications.
- **Notification levels hint** — new ⓘ popover on All Messages, Special Messages, and Keyword Messages headings explaining the Disable / Notify Silent / Notify Loud levels.
- **Descriptive text** — short description added under each notification section heading.
- **Collapse `@room` push rules** — "Mention @room" now shows a single control routing to `IsRoomMention` (MSC3952) on modern servers or `AtRoomNotification` on older ones. Showing both as independent toggles was confusing and caused an apparent sync loop.
- **Per-room switcher** — adds "Follows your global notification rules" subtitle to the Default option.

## Changed files

| File | Change |
|------|--------|
| `src/app/features/settings/notifications/SystemNotification.tsx` | Rename labels; show In-App toggle on all platforms; add Badges section |
| `src/app/features/settings/notifications/AllMessages.tsx` | Descriptive text + levels hint |
| `src/app/features/settings/notifications/SpecialMessages.tsx` | Descriptive text + levels hint; collapse @room control |
| `src/app/features/settings/notifications/KeywordMessages.tsx` | Descriptive text + levels hint |
| `src/app/features/settings/notifications/NotificationLevelsHint.tsx` | **New** — ⓘ popover component |
| `src/app/features/settings/cosmetics/Themes.tsx` | Remove badge settings (moved to Notifications) |
| `src/app/components/RoomNotificationSwitcher.tsx` | "Follows your global rules" subtitle on Default |