### PR TITLE
fix: default badge unread counts to off

### DIFF
--- a/.changeset/fix-notification-defaults.md
+++ b/.changeset/fix-notification-defaults.md
@@ -1,0 +1,7 @@
+---
+sable: patch
+---
+
+fix: default badge unread counts to off
+
+Change `showUnreadCounts` default from `true` to `false`. Unread badges now show a number only for direct mentions by default (Discord-style). Users can re-enable full unread counts in Notifications settings.

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -157,7 +157,7 @@ const defaultSettings: Settings = {
   rightSwipeAction: RightSwipeAction.Reply,
   hideMembershipInReadOnly: true,
   useRightBubbles: false,
-  showUnreadCounts: true,
+  showUnreadCounts: false,
   badgeCountDMsOnly: false,
   showPingCounts: true,
   hideReads: false,


### PR DESCRIPTION
## Summary

Single default value change: `showUnreadCounts` is now `false` by default.

Unread room badges show a number only for direct mentions. Users who want full unread counts can enable them in Settings → Notifications.

This matches Discord's default — most users find "2847 unread" in every room more distracting than helpful.

Note: `useInAppNotifications` remains `mobileOrTablet()` (on for mobile, off for desktop) — unchanged from dev.

## Changed files

| File | Change |
|------|--------|
| `src/app/state/settings.ts` | `showUnreadCounts: true` → `false` |