### PR TITLE
fix properly apply block quotes so that custom html also gets forwarded

### DIFF
--- a/.changeset/fix_properly_apply_block_quotes_so_that_custom_html_also_gets_forwarded.md
+++ b/.changeset/fix_properly_apply_block_quotes_so_that_custom_html_also_gets_forwarded.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+custom emojis are now also visible in forwards, instead of being reduced to it's shortcode

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -153,26 +153,52 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     type SendEventContent = Parameters<typeof mx.sendEvent>[3];
 
     const eventType = mEvent.getType() as SendEventType;
+    const originalContent = mEvent.getContent();
+    const isTextMessage = originalContent.msgtype === 'm.text';
     // using reference relation to indicate that this is a forwarded message,
     // which allows clients to display it as such
 
-    const bodyModifText = `(Forwarded message from ${isPrivate ? 'a private room' : (getRoom(room.roomId)?.name ?? 'a room')})`;
+    const originalBody = typeof originalContent.body === 'string' ? originalContent.body : '';
+    const originalFormattedBody =
+      originalContent.format === 'org.matrix.custom.html' &&
+      typeof originalContent.formatted_body === 'string'
+        ? originalContent.formatted_body
+        : undefined;
+
+    const bodyModifText = `(Forwarded message from ${
+      isPrivate ? 'a private room' : (getRoom(room.roomId)?.name ?? 'a room')
+    })`;
+
     let newBodyPlain = '';
     let newBodyHtml = '';
     // transform if msgtype is m.text
-    if (mEvent.getContent().msgtype === 'm.text') {
-      const original = mEvent.getContent().body;
-      newBodyPlain = `${bodyModifText}\n\n${original
+    if (isTextMessage) {
+      const quotedBody = originalBody
         .split('\n')
-        .map((l: string) => `> ${l}`)
-        .join('\n')}`;
-      const safeHtml = sanitizeCustomHtml(original).replace(/\n/g, '<br>');
+        .map((line) => `> ${line}`)
+        .join('\n');
+
+      newBodyPlain = originalBody.length > 0 ? `${bodyModifText}\n\n${quotedBody}` : bodyModifText;
+
+      const safeHtml =
+        originalFormattedBody !== undefined
+          ? sanitizeCustomHtml(originalFormattedBody)
+          : sanitizeCustomHtml(originalBody).replace(/\n/g, '<br>');
+
       newBodyHtml =
-        `<div class="forwarded" data-forward-marker>` +
+        `<div data-forward-marker>` +
         `<p>${sanitizeCustomHtml(bodyModifText)}</p>` +
         `<blockquote>${safeHtml}</blockquote>` +
         `</div>`;
     }
+    // the quoted body
+    const forwardedTextContent = isTextMessage
+      ? {
+          body: newBodyPlain,
+          format: 'org.matrix.custom.html',
+          formatted_body: newBodyHtml,
+        }
+      : {};
     let content;
     // handle privacy stuff
     if (isPrivate) {
@@ -180,9 +206,7 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
       // we can still include the original message content in the body of the message, so we'll just use a fallback text/plain content with the original message body
       content = {
         ...mEvent.getContent(),
-        body: newBodyPlain,
-        format: 'org.matrix.custom.html',
-        formatted_body: newBodyHtml,
+        ...forwardedTextContent,
         'moe.sable.message.forward': {
           v: 1,
           is_forwarded: true,
@@ -193,9 +217,7 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     } else {
       content = {
         ...mEvent.getContent(),
-        body: newBodyPlain,
-        format: 'org.matrix.custom.html',
-        formatted_body: newBodyHtml,
+        ...forwardedTextContent,
         'm.relates_to': {
           rel_type: 'm.reference',
           event_id: eventId,


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

it now also works with for example custom emojis and a forward of a forward (just that it is a bit email style lol)

<img width="534" height="82" alt="image" src="https://github.com/user-attachments/assets/adde5086-d1a9-45a5-8c3c-cac3db4e075d" />

<img width="539" height="150" alt="image" src="https://github.com/user-attachments/assets/56902fd0-1124-40fe-93de-23e90d28be01" />



Fixes https://github.com/7w1/sable/issues/251

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
