### PR TITLE
fix scroll when clicking message links

### DIFF
--- a/.changeset/a_fix_scroll_links.md
+++ b/.changeset/a_fix_scroll_links.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Fix message links sometimes scrolling to bottom of timeline instead of message + maybe other scroll bugs.

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -620,9 +620,13 @@ export function RoomTimeline({
   }
 
   const atBottomAnchorRef = useRef<HTMLElement>(null);
-  const [atBottom, setAtBottom] = useState<boolean>(true);
+
+  const [atBottom, setAtBottomState] = useState<boolean>(true);
   const atBottomRef = useRef(atBottom);
-  atBottomRef.current = atBottom;
+  const setAtBottom = useCallback((val: boolean) => {
+    setAtBottomState(val);
+    atBottomRef.current = val;
+  }, []);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const scrollToBottomRef = useRef({
@@ -734,6 +738,7 @@ export function RoomTimeline({
         if (!alive()) return;
         const evLength = getTimelinesEventsCount(lTimelines);
 
+        setAtBottom(false);
         setFocusItem({
           index: evtAbsIndex,
           scrollTo: true,
@@ -747,7 +752,7 @@ export function RoomTimeline({
           },
         });
       },
-      [alive]
+      [alive, setAtBottom]
     ),
     useCallback(() => {
       if (!alive()) return;
@@ -829,6 +834,8 @@ export function RoomTimeline({
         evtTimeline && getEventIdAbsoluteIndex(timeline.linkedTimelines, evtTimeline, evtId);
 
       if (typeof absoluteIndex === 'number') {
+        setAtBottom(false);
+
         const scrolled = scrollToItem(absoluteIndex, {
           behavior: reducedMotion ? 'instant' : 'smooth',
           align: 'center',
@@ -837,14 +844,14 @@ export function RoomTimeline({
         if (onScroll) onScroll(scrolled);
         setFocusItem({
           index: absoluteIndex,
-          scrollTo: false,
+          scrollTo: !scrolled,
           highlight,
         });
       } else {
         loadEventTimeline(evtId);
       }
     },
-    [room, timeline, scrollToItem, loadEventTimeline, reducedMotion]
+    [room, timeline, scrollToItem, loadEventTimeline, reducedMotion, setAtBottom]
   );
 
   useLiveTimelineRefresh(
@@ -911,11 +918,15 @@ export function RoomTimeline({
   }, [mx, room, hideReads]);
 
   const debounceSetAtBottom = useDebounce(
-    useCallback((entry: IntersectionObserverEntry) => {
-      if (!entry.isIntersecting) setAtBottom(false);
-    }, []),
+    useCallback(
+      (entry: IntersectionObserverEntry) => {
+        if (!entry.isIntersecting) setAtBottom(false);
+      },
+      [setAtBottom]
+    ),
     { wait: 1000 }
   );
+
   useIntersectionObserver(
     useCallback(
       (entries) => {
@@ -932,7 +943,7 @@ export function RoomTimeline({
           }
         }
       },
-      [debounceSetAtBottom, tryAutoMarkAsRead]
+      [debounceSetAtBottom, tryAutoMarkAsRead, setAtBottom]
     ),
     useCallback(
       () => ({
@@ -1006,36 +1017,20 @@ export function RoomTimeline({
     const contentEl = scrollEl?.firstElementChild as HTMLElement;
     if (!scrollEl || !contentEl) return () => {};
 
-    let lastScrollTop = scrollEl.scrollTop;
-    let userIsScrollingUp = false;
-
-    // Track if user is scrolling up
-    const handleScroll = () => {
-      if (scrollEl.scrollTop < lastScrollTop) {
-        userIsScrollingUp = true;
-      } else if (scrollEl.scrollHeight - scrollEl.scrollTop <= scrollEl.clientHeight + 10) {
-        userIsScrollingUp = false;
-      }
-      lastScrollTop = scrollEl.scrollTop;
-    };
-
     const forceScroll = () => {
       // if the user isn't scrolling jump down to latest content
-      if (!userIsScrollingUp) {
-        scrollToBottom(scrollEl, 'instant');
-      }
+      if (!atBottomRef.current) return;
+      scrollToBottom(scrollEl, 'instant');
     };
 
     const resizeObserver = new ResizeObserver(() => {
       requestAnimationFrame(forceScroll);
     });
 
-    scrollEl.addEventListener('scroll', handleScroll, { passive: true });
     resizeObserver.observe(contentEl);
 
     return () => {
       resizeObserver.disconnect();
-      scrollEl.removeEventListener('scroll', handleScroll);
     };
   }, [room]);
 
@@ -1090,7 +1085,9 @@ export function RoomTimeline({
         // reach the true bottom (e.g. after images finish loading or the
         // virtual keyboard shifts the viewport).
         if (behavior === 'instant') {
-          setTimeout(() => scrollToBottom(scrollEl, 'instant'), 80);
+          setTimeout(() => {
+            scrollToBottom(scrollEl, 'instant');
+          }, 80);
         }
       }
     }


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Fixes timeline jumping down after clicking a message link that links to an already loaded message.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
