### PR TITLE
Manage forwarding state to prevent duplicate forwards in MessageForwardInternal

### DIFF
--- a/.changeset/manage_forwarding_state_to_prevent_duplicate_forwards_in_messageforwardinternal.md
+++ b/.changeset/manage_forwarding_state_to_prevent_duplicate_forwards_in_messageforwardinternal.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+preventing duplicate forwards if the send event is a bit slow

--- a/src/app/components/message/modals/MessageForward.tsx
+++ b/src/app/components/message/modals/MessageForward.tsx
@@ -92,6 +92,7 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
 
   const [isTargetSelected, setIsTargetSelected] = useState(false);
   const [isForwardSuccess, setIsForwardSuccess] = useState(false);
+  const [isForwarding, setIsForwarding] = useState(false);
   const [isForwardError, setIsForwardError] = useState(false);
   const [targetRoomId, setTargetRoomId] = useState<string | null>(null);
 
@@ -143,11 +144,18 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
 
   // actually forward the message to the selected room
   const handleForwardClick = () => {
-    if (!targetRoomId) return;
+    setIsForwarding(true);
+    if (!targetRoomId) {
+      setIsForwarding(false);
+      return;
+    }
 
     const targetRoom = getRoom(targetRoomId);
     const eventId = mEvent.getId();
-    if (!targetRoom || !eventId) return;
+    if (!targetRoom || !eventId) {
+      setIsForwarding(false);
+      return;
+    }
 
     type SendEventType = Parameters<typeof mx.sendEvent>[2];
     type SendEventContent = Parameters<typeof mx.sendEvent>[3];
@@ -212,10 +220,15 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
     }
 
     try {
-      mx.sendEvent(targetRoom.roomId, null, eventType, content as unknown as SendEventContent).then(
-        () => setIsForwardSuccess(true)
-      );
+      mx.sendEvent(targetRoom.roomId, null, eventType, content as unknown as SendEventContent)
+        .then(() => setIsForwardSuccess(true))
+        .catch(() => {
+          setIsForwarding(false);
+          setIsForwardSuccess(false);
+          setIsForwardError(true);
+        });
     } catch {
+      setIsForwarding(false);
       setIsForwardSuccess(false);
       setIsForwardError(true);
     }
@@ -264,7 +277,11 @@ export function MessageForwardInternal({ room, mEvent, onClose }: MessageForward
           </Box>
         </Scroll>
         {isTargetSelected && targetRoomId && (
-          <Button style={{ margin: config.space.S300 }} onClick={handleForwardClick}>
+          <Button
+            style={{ margin: config.space.S300 }}
+            onClick={handleForwardClick}
+            disabled={isForwarding}
+          >
             <Text>Forward to {getRoom(targetRoomId)?.name}</Text>
           </Button>
         )}


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Until now, it could happen that when one forwards a message and while being in the forwarding modal, clicking forward again, and then triggering multiple forwards.

this should now be *mostly* fixed

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
