### PR TITLE
fix: add element-call multi-stage build to Dockerfile

### DIFF
--- a/.changeset/fix-element-call-docker-build.md
+++ b/.changeset/fix-element-call-docker-build.md
@@ -1,0 +1,5 @@
+---
+sable: patch
+---
+
+Fix Docker builds failing after the element-call submodule was introduced.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,18 @@
+## Element Call embedded build
+FROM --platform=$BUILDPLATFORM node:24.13.1-alpine AS element-call-builder
+
+RUN apk add --no-cache git
+
+WORKDIR /element-call
+
+ARG ELEMENT_CALL_COMMIT=ecef381c246c177af28b8c99c5076da19878a136
+RUN git init && \
+    git remote add origin https://github.com/melogale/element-call.git && \
+    git fetch --depth=1 origin ${ELEMENT_CALL_COMMIT} && \
+    git checkout FETCH_HEAD
+
+RUN corepack enable && yarn install && yarn build:embedded
+
 ## Builder
 FROM --platform=$BUILDPLATFORM node:24.13.1-alpine AS builder
 
@@ -7,6 +22,10 @@ ARG VITE_BUILD_HASH
 ARG VITE_IS_RELEASE_TAG=false
 ENV VITE_BUILD_HASH=$VITE_BUILD_HASH
 ENV VITE_IS_RELEASE_TAG=$VITE_IS_RELEASE_TAG
+
+# Copy the pre-built element-call embedded package so npm ci can resolve the
+# file: dependency and vite can find the dist/ assets to copy.
+COPY --from=element-call-builder /element-call/embedded/web /src/element-call/embedded/web
 
 COPY .npmrc package.json package-lock.json /src/
 RUN npm ci --ignore-scripts


### PR DESCRIPTION
## Problem

After merging the "avatars!" PR (#227), which added `element-call` as a git submodule and `@element-hq/element-call-embedded` as a `file:element-call/embedded/web` dependency, Docker builds fail with:

```
[vite-plugin-static-copy:build] No file was found to copy on node_modules/@element-hq/element-call-embedded/dist/* src.
```

The Dockerfile had no step to fetch or build the submodule, so `embedded/web/dist/` was never populated.

## Solution

Add a new `element-call-builder` stage before the main `builder` that:

1. Fetches the pinned submodule commit (`ecef381c`) from the element-call repo with `--depth=1`
2. Runs `corepack enable` to activate Yarn 4.x (the repo's `packageManager` field requires it — the Alpine Node image only ships Yarn 1.x)
3. Runs `yarn build:embedded` from the repo root, which outputs to `embedded/web/dist/`

The `builder` stage then uses `COPY --from=element-call-builder` to place the pre-built package at `element-call/embedded/web` before `npm ci` runs, so npm resolves the `file:` dependency and vite finds the `dist/` assets.